### PR TITLE
Rename package to `@jupyterlite/terminal`

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,14 +1,14 @@
 # Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
 _commit: v4.3.0
 _src_path: https://github.com/jupyterlab/extension-template
-author_email: ianthomas23@gmail.com
-author_name: Ian Thomas
+author_email: 
+author_name: JupyterLite Contributors
 has_binder: false
 has_settings: false
 kind: frontend
-labextension_name: jupyterlite-terminal
+labextension_name: "@jupyterlite/terminal"
 project_short_description: A terminal for JupyterLite
 python_name: jupyterlite_terminal
-repository: https://github.com/ianthomas23/jupyterlite-terminal
+repository: https://github.com/jupyterlite/terminal
 test: true
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
         python -m pip install .[test]
 
         jupyter labextension list
-        jupyter labextension list 2>&1 | grep -ie "jupyterlite-terminal.*OK"
+        jupyter labextension list 2>&1 | grep -ie "@jupyterlite/terminal.*OK"
 
     - name: Package the extension
       run: |
@@ -81,7 +81,7 @@ jobs:
         pip install "jupyterlab>=4.0.0,<5" jupyterlite_terminal*.whl
 
         jupyter labextension list
-        jupyter labextension list 2>&1 | grep -ie "jupyterlite-terminal.*OK"
+        jupyter labextension list 2>&1 | grep -ie "@jupyterlite/terminal.*OK"
 
   integration-tests:
     name: Integration tests

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 BSD 3-Clause License
 
-Copyright (c) 2024, Ian Thomas
+Copyright (c), Ian Thomas
+Copyright (c), JupyterLite Contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # jupyterlite_terminal
 
-[![Github Actions Status](https://github.com/ianthomas23/jupyterlite-terminal/workflows/Build/badge.svg)](https://github.com/ianthomas23/jupyterlite-terminal/actions/workflows/build.yml)
+[![Github Actions Status](https://github.com/jupyterlite/terminal/workflows/Build/badge.svg)](https://github.com/jupyterlite/terminal/actions/workflows/build.yml)
 
 A terminal for JupyterLite.
 
 ⚠️ This extension is still in development and not yet ready for general use. ⚠️
 
-![a screenshot showing a terminal running in JupyterLite](https://github.com/ianthomas23/jupyterlite-terminal/assets/591645/1b4ff620-e8f2-4abf-b608-6badd66370ac)
+![a screenshot showing a terminal running in JupyterLite](https://github.com/jupyterlite/terminal/assets/591645/1b4ff620-e8f2-4abf-b608-6badd66370ac)
 
 ## Requirements
 

--- a/package.json
+++ b/package.json
@@ -57,10 +57,10 @@
         "watch:labextension": "jupyter labextension watch ."
     },
     "dependencies": {
-        "@ianthomas23/cockle": "^0.0.2",
         "@jupyterlab/services": "^7.2.0",
         "@jupyterlab/terminal": "^4.2.0",
         "@jupyterlab/terminal-extension": "^4.2.0",
+        "@jupyterlite/cockle": "^0.0.3",
         "@jupyterlite/server": "^0.3.0",
         "@lumino/coreutils": "^2.1.2",
         "mock-socket": "^9.3.1"

--- a/package.json
+++ b/package.json
@@ -8,14 +8,14 @@
         "jupyterlite",
         "jupyterlite-extension"
     ],
-    "homepage": "https://github.com/ianthomas23/jupyterlite-terminal",
+    "homepage": "https://github.com/jupyterlite/terminal",
     "bugs": {
-        "url": "https://github.com/ianthomas23/jupyterlite-terminal/issues"
+        "url": "https://github.com/jupyterlite/terminal/issues"
     },
     "license": "BSD-3-Clause",
     "author": {
-        "name": "Ian Thomas",
-        "email": "ianthomas23@gmail.com"
+        "name": "JupyterLite Contributors",
+        "email": ""
     },
     "files": [
         "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
@@ -27,7 +27,7 @@
     "style": "style/index.css",
     "repository": {
         "type": "git",
-        "url": "https://github.com/ianthomas23/jupyterlite-terminal.git"
+        "url": "https://github.com/jupyterlite/terminal.git"
     },
     "scripts": {
         "build": "jlpm build:lib && jlpm build:labextension:dev",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "jupyterlite-terminal",
+    "name": "@jupyterlite/terminal",
     "version": "0.1.0",
     "description": "A terminal for JupyterLite",
     "keywords": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,13 +14,13 @@ import { Terminals } from './terminals';
  * The terminals service plugin.
  */
 const terminalsPlugin: JupyterLiteServerPlugin<ITerminals> = {
-  id: 'jupyterlite-terminal:plugin',
+  id: '@jupyterlite/terminal:plugin',
   description: 'A terminal for JupyterLite',
   autoStart: true,
   provides: ITerminals,
   activate: async (app: JupyterLiteServer) => {
     console.log(
-      'JupyterLab extension jupyterlite-terminal:plugin is activated!'
+      'JupyterLab extension @jupyterlite/terminal:plugin is activated!'
     );
 
     const { serviceManager } = app;
@@ -41,12 +41,12 @@ const terminalsPlugin: JupyterLiteServerPlugin<ITerminals> = {
  * A plugin providing the routes for the terminals service
  */
 const terminalsRoutesPlugin: JupyterLiteServerPlugin<void> = {
-  id: 'jupyterlite-terminal:routes-plugin',
+  id: '@jupyterlite/terminal:routes-plugin',
   autoStart: true,
   requires: [ITerminals],
   activate: (app: JupyterLiteServer, terminals: ITerminals) => {
     console.log(
-      'JupyterLab extension jupyterlite-terminal:routes-plugin is activated!',
+      'JupyterLab extension @jupyterlite/terminal:routes-plugin is activated!',
       terminals
     );
 

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { JupyterFileSystem, Shell, IFileSystem } from '@ianthomas23/cockle';
+import { JupyterFileSystem, Shell, IFileSystem } from '@jupyterlite/cockle';
 
 import { JSONPrimitive } from '@lumino/coreutils';
 

--- a/ui-tests/tests/jupyterlite_terminal.spec.ts
+++ b/ui-tests/tests/jupyterlite_terminal.spec.ts
@@ -18,7 +18,7 @@ test.skip('should emit an activation console message', async ({ page }) => {
 
   expect(
     logs.filter(
-      s => s === 'JupyterLab extension jupyterlite-terminal is activated!'
+      s => s === 'JupyterLab extension @jupyterlite/terminal is activated!'
     )
   ).toHaveLength(1);
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1746,15 +1746,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ianthomas23/cockle@npm:^0.0.2":
-  version: 0.0.2
-  resolution: "@ianthomas23/cockle@npm:0.0.2"
-  dependencies:
-    "@jupyterlab/services": ^7.1.6
-  checksum: 7426122ce9e05cebf6db3c88a06b068eafa65dc8a6ba72384c6a9a62f95d13ebc3a3cb865ecaa6989a8809d0a0fc17155689be7d6067d5f3ffb4e0dbb0a32d33
-  languageName: node
-  linkType: hard
-
 "@isaacs/cliui@npm:^8.0.2":
   version: 8.0.2
   resolution: "@isaacs/cliui@npm:8.0.2"
@@ -3004,6 +2995,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jupyterlite/cockle@npm:^0.0.3":
+  version: 0.0.3
+  resolution: "@jupyterlite/cockle@npm:0.0.3"
+  dependencies:
+    "@jupyterlab/services": ^7.1.6
+  checksum: 78451875892662175ba5f7bfac36ba97f6a1d2335ec8d801d39fd2dcd7f2996af08c0b5d76d67921843e888d7a94a70f43a24ade7d476c8b7556e775d1a8002f
+  languageName: node
+  linkType: hard
+
 "@jupyterlite/contents@npm:^0.3.0":
   version: 0.3.0
   resolution: "@jupyterlite/contents@npm:0.3.0"
@@ -3102,12 +3102,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlite/terminal@workspace:."
   dependencies:
-    "@ianthomas23/cockle": ^0.0.2
     "@jupyterlab/builder": ^4.0.0
     "@jupyterlab/services": ^7.2.0
     "@jupyterlab/terminal": ^4.2.0
     "@jupyterlab/terminal-extension": ^4.2.0
     "@jupyterlab/testutils": ^4.0.0
+    "@jupyterlite/cockle": ^0.0.3
     "@jupyterlite/server": ^0.3.0
     "@lumino/coreutils": ^2.1.2
     "@types/jest": ^29.2.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -3098,6 +3098,45 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jupyterlite/terminal@workspace:.":
+  version: 0.0.0-use.local
+  resolution: "@jupyterlite/terminal@workspace:."
+  dependencies:
+    "@ianthomas23/cockle": ^0.0.2
+    "@jupyterlab/builder": ^4.0.0
+    "@jupyterlab/services": ^7.2.0
+    "@jupyterlab/terminal": ^4.2.0
+    "@jupyterlab/terminal-extension": ^4.2.0
+    "@jupyterlab/testutils": ^4.0.0
+    "@jupyterlite/server": ^0.3.0
+    "@lumino/coreutils": ^2.1.2
+    "@types/jest": ^29.2.0
+    "@types/json-schema": ^7.0.11
+    "@types/react": ^18.0.26
+    "@types/react-addons-linked-state-mixin": ^0.14.22
+    "@typescript-eslint/eslint-plugin": ^6.1.0
+    "@typescript-eslint/parser": ^6.1.0
+    css-loader: ^6.7.1
+    eslint: ^8.36.0
+    eslint-config-prettier: ^8.8.0
+    eslint-plugin-prettier: ^5.0.0
+    jest: ^29.2.0
+    mock-socket: ^9.3.1
+    npm-run-all: ^4.1.5
+    prettier: ^3.0.0
+    rimraf: ^5.0.1
+    source-map-loader: ^1.0.2
+    style-loader: ^3.3.1
+    stylelint: ^15.10.1
+    stylelint-config-recommended: ^13.0.0
+    stylelint-config-standard: ^34.0.0
+    stylelint-csstree-validator: ^3.0.0
+    stylelint-prettier: ^4.0.0
+    typescript: ~5.0.2
+    yjs: ^13.5.0
+  languageName: unknown
+  linkType: soft
+
 "@jupyterlite/translation@npm:^0.3.0":
   version: 0.3.0
   resolution: "@jupyterlite/translation@npm:0.3.0"
@@ -7690,45 +7729,6 @@ __metadata:
   checksum: 0b40f712900ad0c846681ea2db23b6684b9d5eedf55807b4708c656f5894b63507d0e28ae10aa1bddbea551241035afe62b6df0800fc94c2e2806a7f3adecd7c
   languageName: node
   linkType: hard
-
-"jupyterlite-terminal@workspace:.":
-  version: 0.0.0-use.local
-  resolution: "jupyterlite-terminal@workspace:."
-  dependencies:
-    "@ianthomas23/cockle": ^0.0.2
-    "@jupyterlab/builder": ^4.0.0
-    "@jupyterlab/services": ^7.2.0
-    "@jupyterlab/terminal": ^4.2.0
-    "@jupyterlab/terminal-extension": ^4.2.0
-    "@jupyterlab/testutils": ^4.0.0
-    "@jupyterlite/server": ^0.3.0
-    "@lumino/coreutils": ^2.1.2
-    "@types/jest": ^29.2.0
-    "@types/json-schema": ^7.0.11
-    "@types/react": ^18.0.26
-    "@types/react-addons-linked-state-mixin": ^0.14.22
-    "@typescript-eslint/eslint-plugin": ^6.1.0
-    "@typescript-eslint/parser": ^6.1.0
-    css-loader: ^6.7.1
-    eslint: ^8.36.0
-    eslint-config-prettier: ^8.8.0
-    eslint-plugin-prettier: ^5.0.0
-    jest: ^29.2.0
-    mock-socket: ^9.3.1
-    npm-run-all: ^4.1.5
-    prettier: ^3.0.0
-    rimraf: ^5.0.1
-    source-map-loader: ^1.0.2
-    style-loader: ^3.3.1
-    stylelint: ^15.10.1
-    stylelint-config-recommended: ^13.0.0
-    stylelint-config-standard: ^34.0.0
-    stylelint-csstree-validator: ^3.0.0
-    stylelint-prettier: ^4.0.0
-    typescript: ~5.0.2
-    yjs: ^13.5.0
-  languageName: unknown
-  linkType: soft
 
 "keyv@npm:^4.5.3":
   version: 4.5.4


### PR DESCRIPTION
Follow-up to the move to the `jupyterlite` organization.

- [x] Rename top-level name to `@jupyterlite/terminal`
- [x] Update links to the repo
- [x] Update dependency on `cockle`