### PR TITLE
Reset version for initial release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@jupyterlite/terminal",
-    "version": "0.1.0",
+    "version": "0.0.1",
     "description": "A terminal for JupyterLite",
     "keywords": [
         "jupyter",


### PR DESCRIPTION
Follow-up to #7, so we can bump the version to `0.1.0` during the release.