### PR TITLE
Fix listing of terminals

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ const terminalsRoutesPlugin: JupyterLiteServerPlugin<void> = {
 
     // GET /api/terminals - List the running terminals
     app.router.get('/api/terminals', async (req: Router.IRequest) => {
-      const res = terminals.list();
+      const res = await terminals.list();
       // Should return last_activity for each too,
       return new Response(JSON.stringify(res));
     });


### PR DESCRIPTION
Fixes #6 

![image](https://github.com/jupyterlite/terminal/assets/591645/1d704718-917d-4120-8033-94aba488bc08)
