### PR TITLE
Replace postMessage from webworker with comlink callback

### DIFF
--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -3,9 +3,11 @@
 
 import { TerminalAPI } from '@jupyterlab/services';
 
+import { IOutputCallback } from '@jupyterlite/cockle';
+
 import { Token } from '@lumino/coreutils';
 
-import { Remote } from 'comlink';
+import { ProxyMarked, Remote } from 'comlink';
 
 /**
  * The token for the Terminals service.
@@ -71,11 +73,17 @@ export namespace IWorkerTerminal {
   }
 }
 
+export namespace IRemote {
+  export type OutputCallback = IOutputCallback & ProxyMarked;
+}
+
 export interface IRemote extends IWorkerTerminal {
   /**
    * Handle any lazy initialization activities.
    */
   initialize(options: IWorkerTerminal.IOptions): Promise<void>;
+
+  registerCallbacks(outputCallback: IRemote.OutputCallback): void;
 }
 
 /**


### PR DESCRIPTION
Currently using `postMessage` to send messages from the WebWorker to the main thread. This PR replaces this with the use of a comlink-compatible callback which allows us to add type annotations to the callback code.