### PR TITLE
Update jupyterlite to 0.4.0 and cockle to 0.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,9 +62,9 @@
         "@jupyterlab/services": "^7.2.0",
         "@jupyterlab/terminal": "^4.2.0",
         "@jupyterlab/terminal-extension": "^4.2.0",
-        "@jupyterlite/cockle": "^0.0.4",
-        "@jupyterlite/contents": "^0.3.0 || ^0.4.0-beta.0",
-        "@jupyterlite/server": "^0.3.0 || ^0.4.0-beta.0",
+        "@jupyterlite/cockle": "^0.0.5",
+        "@jupyterlite/contents": "^0.4.0",
+        "@jupyterlite/server": "^0.4.0",
         "@lumino/coreutils": "^2.1.2",
         "comlink": "^4.4.1",
         "mock-socket": "^9.3.1"

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -24,7 +24,10 @@ class WorkerTerminal implements IWorkerTerminal {
   }
 
   async start(): Promise<void> {
-    this._shell = new Shell(this.output.bind(this), this._mountpoint);
+    this._shell = new Shell({
+      mountpoint: this._mountpoint,
+      outputCallback: this.output.bind(this),
+    });
     const { FS, PATH, ERRNO_CODES } = await this._shell.initFilesystem();
 
     if (this._wantDriveFS) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2092,20 +2092,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyter/ydoc@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "@jupyter/ydoc@npm:1.1.1"
-  dependencies:
-    "@jupyterlab/nbformat": ^3.0.0 || ^4.0.0-alpha.21 || ^4.0.0
-    "@lumino/coreutils": ^1.11.0 || ^2.0.0
-    "@lumino/disposable": ^1.10.0 || ^2.0.0
-    "@lumino/signaling": ^1.10.0 || ^2.0.0
-    y-protocols: ^1.0.5
-    yjs: ^13.5.40
-  checksum: a239b1dd57cfc9ba36c06ac5032a1b6388849ae01a1d0db0d45094f71fdadf4d473b4bf8becbef0cfcdc85cae505361fbec0822b02da5aa48e06b66f742dd7a0
-  languageName: node
-  linkType: hard
-
 "@jupyter/ydoc@npm:^2.0.1":
   version: 2.0.1
   resolution: "@jupyter/ydoc@npm:2.0.1"
@@ -2334,7 +2320,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/coreutils@npm:^6.1.8, @jupyterlab/coreutils@npm:^6.2.2, @jupyterlab/coreutils@npm:^6.2.3":
+"@jupyterlab/coreutils@npm:^6.2.2, @jupyterlab/coreutils@npm:^6.2.3":
   version: 6.2.3
   resolution: "@jupyterlab/coreutils@npm:6.2.3"
   dependencies:
@@ -2348,9 +2334,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/coreutils@npm:~6.1.5":
-  version: 6.1.8
-  resolution: "@jupyterlab/coreutils@npm:6.1.8"
+"@jupyterlab/coreutils@npm:^6.2.4, @jupyterlab/coreutils@npm:~6.2.4":
+  version: 6.2.4
+  resolution: "@jupyterlab/coreutils@npm:6.2.4"
   dependencies:
     "@lumino/coreutils": ^2.1.2
     "@lumino/disposable": ^2.1.2
@@ -2358,7 +2344,7 @@ __metadata:
     minimist: ~1.2.0
     path-browserify: ^1.0.0
     url-parse: ~1.5.4
-  checksum: 1049c78bdbffb247fe7e7be4e082fe15711ca0d8da997d6da7042e0299d7ebbf1d0341d830ae0ab451bf8dfbfc30027bf3f063fc7e35210409a7aa56fe94cee9
+  checksum: 4ce2c660dea8a174e805b00cdecfa0b00fd7500cd07f5fbb62c69b48722728162baf90dc9c86c8e72044052d9c0217a53d12a7a5ebdbe9714865d18b8e66593f
   languageName: node
   linkType: hard
 
@@ -2516,7 +2502,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/nbformat@npm:^3.0.0 || ^4.0.0-alpha.21 || ^4.0.0, @jupyterlab/nbformat@npm:^4.1.8, @jupyterlab/nbformat@npm:^4.2.3":
+"@jupyterlab/nbformat@npm:^3.0.0 || ^4.0.0-alpha.21 || ^4.0.0, @jupyterlab/nbformat@npm:^4.2.3":
   version: 4.2.3
   resolution: "@jupyterlab/nbformat@npm:4.2.3"
   dependencies:
@@ -2525,12 +2511,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/nbformat@npm:~4.1.5":
-  version: 4.1.8
-  resolution: "@jupyterlab/nbformat@npm:4.1.8"
+"@jupyterlab/nbformat@npm:^4.2.4, @jupyterlab/nbformat@npm:~4.2.4":
+  version: 4.2.4
+  resolution: "@jupyterlab/nbformat@npm:4.2.4"
   dependencies:
     "@lumino/coreutils": ^2.1.2
-  checksum: 11d89ae6fb2385a00e60ab84defc61e3cf28510b029ffbe9ffe27a75bc84f85e64a0d0d16b6deb7b57256fdd651d842a0626128def511e7755121a5a0a71f078
+  checksum: 61ac75dbaa32ef196eb9e177529ba259c6b0648601646b52ec8a1b25dbca4fce8c6d78090b47fd0674bf993f883fa62223dc52e50a59f1b2c843a9d5c8d02ef4
   languageName: node
   linkType: hard
 
@@ -2585,16 +2571,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/observables@npm:~5.1.5":
-  version: 5.1.8
-  resolution: "@jupyterlab/observables@npm:5.1.8"
+"@jupyterlab/observables@npm:~5.2.4":
+  version: 5.2.4
+  resolution: "@jupyterlab/observables@npm:5.2.4"
   dependencies:
     "@lumino/algorithm": ^2.0.1
     "@lumino/coreutils": ^2.1.2
     "@lumino/disposable": ^2.1.2
     "@lumino/messaging": ^2.0.1
     "@lumino/signaling": ^2.1.2
-  checksum: c349b4fea92ef28019c0b3f5a100abdd4384554188d6741234e90e03f3f18b343a22ea8560f9d2eea1a00d4cd9514074d195ec850e930785f28a2f8a624a0f4d
+  checksum: 48af3aadfafa8707643678f127d6c9e4e9a2b9ad009cfdbf9de5df7212bfbbb213ab786b05364d647477416a790580b4fd9aa8ade817fd9108df23a815741b05
   languageName: node
   linkType: hard
 
@@ -2688,26 +2674,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/services@npm:~7.1.5":
-  version: 7.1.8
-  resolution: "@jupyterlab/services@npm:7.1.8"
+"@jupyterlab/services@npm:~7.2.4":
+  version: 7.2.4
+  resolution: "@jupyterlab/services@npm:7.2.4"
   dependencies:
-    "@jupyter/ydoc": ^1.1.1
-    "@jupyterlab/coreutils": ^6.1.8
-    "@jupyterlab/nbformat": ^4.1.8
-    "@jupyterlab/settingregistry": ^4.1.8
-    "@jupyterlab/statedb": ^4.1.8
+    "@jupyter/ydoc": ^2.0.1
+    "@jupyterlab/coreutils": ^6.2.4
+    "@jupyterlab/nbformat": ^4.2.4
+    "@jupyterlab/settingregistry": ^4.2.4
+    "@jupyterlab/statedb": ^4.2.4
     "@lumino/coreutils": ^2.1.2
     "@lumino/disposable": ^2.1.2
     "@lumino/polling": ^2.1.2
     "@lumino/properties": ^2.0.1
     "@lumino/signaling": ^2.1.2
     ws: ^8.11.0
-  checksum: 56143631829ee1081f6ad2f03343a47d83549d2463f9c4bfddb34e4770c74cf78cbcc5f54aca5338a0d5ce4d28e9b8d8301e6e04b4fb7f66570c49d1ceaf19e5
+  checksum: 7262d6ac6bc8a41e03ec45c7d4dd8e8eb2547dff315a9be9c81cff0e5f4f9e3fb12fd3d008cb4132efced9800023470fb5fef5f446307903b8cdee8c1ca96d34
   languageName: node
   linkType: hard
 
-"@jupyterlab/settingregistry@npm:^4.1.8, @jupyterlab/settingregistry@npm:^4.2.3":
+"@jupyterlab/settingregistry@npm:^4.2.3":
   version: 4.2.3
   resolution: "@jupyterlab/settingregistry@npm:4.2.3"
   dependencies:
@@ -2726,13 +2712,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/settingregistry@npm:~4.1.5":
-  version: 4.1.8
-  resolution: "@jupyterlab/settingregistry@npm:4.1.8"
+"@jupyterlab/settingregistry@npm:^4.2.4, @jupyterlab/settingregistry@npm:~4.2.4":
+  version: 4.2.4
+  resolution: "@jupyterlab/settingregistry@npm:4.2.4"
   dependencies:
-    "@jupyterlab/nbformat": ^4.1.8
-    "@jupyterlab/statedb": ^4.1.8
-    "@lumino/commands": ^2.2.0
+    "@jupyterlab/nbformat": ^4.2.4
+    "@jupyterlab/statedb": ^4.2.4
+    "@lumino/commands": ^2.3.0
     "@lumino/coreutils": ^2.1.2
     "@lumino/disposable": ^2.1.2
     "@lumino/signaling": ^2.1.2
@@ -2741,11 +2727,11 @@ __metadata:
     json5: ^2.2.3
   peerDependencies:
     react: ">=16"
-  checksum: 90067142211fdaf6e9a6e0029fe1bc4c9ae05fa8e88e37f912373a0365bc8d507ef44e0bf83deb1e0bd0855a2cf05b0f541db38fafe3bc37d83422df8671e56a
+  checksum: c4d1bfef80811697c0979f76b3a0c1f6597d6f07fd227004fd7f1237abc20ac6dda4cfffcb487166625e3c72ffa5c9e25e0a865c86217e9280207362b8864247
   languageName: node
   linkType: hard
 
-"@jupyterlab/statedb@npm:^4.1.8, @jupyterlab/statedb@npm:^4.2.3":
+"@jupyterlab/statedb@npm:^4.2.3":
   version: 4.2.3
   resolution: "@jupyterlab/statedb@npm:4.2.3"
   dependencies:
@@ -2758,16 +2744,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/statedb@npm:~4.1.5":
-  version: 4.1.8
-  resolution: "@jupyterlab/statedb@npm:4.1.8"
+"@jupyterlab/statedb@npm:^4.2.4, @jupyterlab/statedb@npm:~4.2.4":
+  version: 4.2.4
+  resolution: "@jupyterlab/statedb@npm:4.2.4"
   dependencies:
-    "@lumino/commands": ^2.2.0
+    "@lumino/commands": ^2.3.0
     "@lumino/coreutils": ^2.1.2
     "@lumino/disposable": ^2.1.2
     "@lumino/properties": ^2.0.1
     "@lumino/signaling": ^2.1.2
-  checksum: 28983e98affec8b8d6bb8e0cbacfe2c74d1ae48af8e69fddc7f457dcd87210adf5e39dafd21bcad24cfe572f45758c7531cd8d991e9eda894e63392b544bf09d
+  checksum: 63d2eeab1e4f45593b417f7aa4bbff5a78703858d2c49497632f37d262acca37e4600766dcd3d744de4048ba8e6726dcbe44718453a1d43eb088380f48e70609
   languageName: node
   linkType: hard
 
@@ -2928,107 +2914,107 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlite/cockle@npm:^0.0.4":
-  version: 0.0.4
-  resolution: "@jupyterlite/cockle@npm:0.0.4"
+"@jupyterlite/cockle@npm:^0.0.5":
+  version: 0.0.5
+  resolution: "@jupyterlite/cockle@npm:0.0.5"
   dependencies:
     "@jupyterlab/services": ^7.1.6
-    "@jupyterlite/contents": ^0.3.0
-  checksum: 70f5c3f8c831c6ae0d0ec0e16d1f7972678299fdbfa83eef109997d4b2b14ac09d2f60152fd9f80599afd1b80e80b8e6d0fbc75f35d29928d8b96ef0d67a92a0
+    "@jupyterlite/contents": ^0.4.0-beta.0
+  checksum: d75b2f4f1741a61fbf059533a067cc6cd13aac69a2c72473bad7012b361c0ea75c83dfac2a7c77c74c5d0bfa08e1e4d769e2a7fb4f3a9d40e6651e96842efe56
   languageName: node
   linkType: hard
 
-"@jupyterlite/contents@npm:^0.3.0, @jupyterlite/contents@npm:^0.3.0 || ^0.4.0-beta.0":
-  version: 0.3.0
-  resolution: "@jupyterlite/contents@npm:0.3.0"
+"@jupyterlite/contents@npm:^0.4.0, @jupyterlite/contents@npm:^0.4.0-beta.0":
+  version: 0.4.0
+  resolution: "@jupyterlite/contents@npm:0.4.0"
   dependencies:
-    "@jupyterlab/nbformat": ~4.1.5
-    "@jupyterlab/services": ~7.1.5
-    "@jupyterlite/localforage": ^0.3.0
+    "@jupyterlab/nbformat": ~4.2.4
+    "@jupyterlab/services": ~7.2.4
+    "@jupyterlite/localforage": ^0.4.0
     "@lumino/coreutils": ^2.1.2
     "@types/emscripten": ^1.39.6
     localforage: ^1.9.0
     mime: ^3.0.0
-  checksum: b0ca5e9b377c1a312cc04cbc9fce01355a3c956e5760f0ca5db42a520b7285e86cd386703183f3bee997a77ee7a26921b50bfed6e511a9f7f703c375863b1bd9
+  checksum: b5959002bc9a4438b626e2a4a77467730c0e868eedc5f2af7e3fc81473ce33d5007d85cfbd0d43e20dca33aa2bbd175cece61776c55df0636b063afeb43511d4
   languageName: node
   linkType: hard
 
-"@jupyterlite/kernel@npm:^0.3.0":
-  version: 0.3.0
-  resolution: "@jupyterlite/kernel@npm:0.3.0"
+"@jupyterlite/kernel@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "@jupyterlite/kernel@npm:0.4.0"
   dependencies:
-    "@jupyterlab/coreutils": ~6.1.5
-    "@jupyterlab/observables": ~5.1.5
-    "@jupyterlab/services": ~7.1.5
+    "@jupyterlab/coreutils": ~6.2.4
+    "@jupyterlab/observables": ~5.2.4
+    "@jupyterlab/services": ~7.2.4
     "@lumino/coreutils": ^2.1.2
     "@lumino/disposable": ^2.1.2
     "@lumino/signaling": ^2.1.2
     async-mutex: ^0.3.1
     comlink: ^4.3.1
     mock-socket: ^9.1.0
-  checksum: 0c1c4e19077c910f9808b1c14bee98ae0f5af1ed86bd4b8768942fc2717a9834618693686892b3efa455e77014540522dc491d74b6dd9a2d41ad8148d275d802
+  checksum: d0e37ef887e6a0800b37c46fc125a75016477040c318e1f0253c01ad866eaf1d798597c0ff48bc91b0b58196a4a901e4a090ffe3e96ccb7c028e7ab8fb02b1b9
   languageName: node
   linkType: hard
 
-"@jupyterlite/localforage@npm:^0.3.0":
-  version: 0.3.0
-  resolution: "@jupyterlite/localforage@npm:0.3.0"
+"@jupyterlite/localforage@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "@jupyterlite/localforage@npm:0.4.0"
   dependencies:
-    "@jupyterlab/coreutils": ~6.1.5
+    "@jupyterlab/coreutils": ~6.2.4
     "@lumino/coreutils": ^2.1.2
     localforage: ^1.9.0
     localforage-memoryStorageDriver: ^0.9.2
-  checksum: e090fe2b0ff18d230ef14e9f69c788b92432c30efeca0222d33378d8282399d86fe8ec446f7cdd29ae13ee31de8b7f2f73c1d03a5504b58c8297c17d8db8bb12
+  checksum: 30454003c7bb740828ea93e7cbe012336a891f27c9b4711b09872fb0b8b1b901a55b790ddbe289dde00a46b2224721e6558db9077163f6fbe10830d9ab937c22
   languageName: node
   linkType: hard
 
-"@jupyterlite/server@npm:^0.3.0 || ^0.4.0-beta.0":
-  version: 0.3.0
-  resolution: "@jupyterlite/server@npm:0.3.0"
+"@jupyterlite/server@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "@jupyterlite/server@npm:0.4.0"
   dependencies:
-    "@jupyterlab/coreutils": ~6.1.5
-    "@jupyterlab/nbformat": ~4.1.5
-    "@jupyterlab/observables": ~5.1.5
-    "@jupyterlab/services": ~7.1.5
-    "@jupyterlab/settingregistry": ~4.1.5
-    "@jupyterlab/statedb": ~4.1.5
-    "@jupyterlite/contents": ^0.3.0
-    "@jupyterlite/kernel": ^0.3.0
-    "@jupyterlite/session": ^0.3.0
-    "@jupyterlite/settings": ^0.3.0
-    "@jupyterlite/translation": ^0.3.0
-    "@lumino/application": ^2.3.0
+    "@jupyterlab/coreutils": ~6.2.4
+    "@jupyterlab/nbformat": ~4.2.4
+    "@jupyterlab/observables": ~5.2.4
+    "@jupyterlab/services": ~7.2.4
+    "@jupyterlab/settingregistry": ~4.2.4
+    "@jupyterlab/statedb": ~4.2.4
+    "@jupyterlite/contents": ^0.4.0
+    "@jupyterlite/kernel": ^0.4.0
+    "@jupyterlite/session": ^0.4.0
+    "@jupyterlite/settings": ^0.4.0
+    "@jupyterlite/translation": ^0.4.0
+    "@lumino/application": ^2.3.1
     "@lumino/coreutils": ^2.1.2
     "@lumino/signaling": ^2.1.2
     mock-socket: ^9.1.0
-  checksum: d7b738dd5eb4cfd75539241d4d8ebe279e095eea675d142a30181f4f84b381c8aab8400a986bc97d3be4c33793da715211660357782af47d4d4f9f3e10d0416a
+  checksum: 2ed786b878b5822cd4a2d3db6b2c61ebfd883ed5d342f85e620a2eefd3eb8226156e7971637d138540b15fd75db25183ea3d02ee7f7b0b67b57dd61cb6e3f80e
   languageName: node
   linkType: hard
 
-"@jupyterlite/session@npm:^0.3.0":
-  version: 0.3.0
-  resolution: "@jupyterlite/session@npm:0.3.0"
+"@jupyterlite/session@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "@jupyterlite/session@npm:0.4.0"
   dependencies:
-    "@jupyterlab/coreutils": ~6.1.5
-    "@jupyterlab/services": ~7.1.5
-    "@jupyterlite/kernel": ^0.3.0
+    "@jupyterlab/coreutils": ~6.2.4
+    "@jupyterlab/services": ~7.2.4
+    "@jupyterlite/kernel": ^0.4.0
     "@lumino/algorithm": ^2.0.1
     "@lumino/coreutils": ^2.1.2
-  checksum: 80e62c15b77d54f20a904aec741d602f14c87de8e6a67b54fe7d76615dfc7dbe747c79b48863441b89c7a20dc933444609d2ee21387d7b85b041bddb2eb86036
+  checksum: e2fd1ed5900e1781b01dec7b1ce230132a5a8f84f7f84fdfe09745291305e0936cf269bfc5c394625b72ac709e6cf5da2e8910b4ef00d8b0c60b3343a0db89f7
   languageName: node
   linkType: hard
 
-"@jupyterlite/settings@npm:^0.3.0":
-  version: 0.3.0
-  resolution: "@jupyterlite/settings@npm:0.3.0"
+"@jupyterlite/settings@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "@jupyterlite/settings@npm:0.4.0"
   dependencies:
-    "@jupyterlab/coreutils": ~6.1.5
-    "@jupyterlab/settingregistry": ~4.1.5
-    "@jupyterlite/localforage": ^0.3.0
+    "@jupyterlab/coreutils": ~6.2.4
+    "@jupyterlab/settingregistry": ~4.2.4
+    "@jupyterlite/localforage": ^0.4.0
     "@lumino/coreutils": ^2.1.2
     json5: ^2.2.0
     localforage: ^1.9.0
-  checksum: 343f88fe19cf9b24c1f518bf99d288204e922cddf584bff7424ee5ec52c2824a45b7958c3642a53126bedcc8b400289297b21f02dba5326d801f71c6b30a790e
+  checksum: 3547d73d4c63e1b36654145a0f3752e4a040be993ecd66f1b9156f1da526e78dbfe5b11f2990369af4cfdd8fc14850a849a103b603e859f7b0312306a9f2f07d
   languageName: node
   linkType: hard
 
@@ -3042,9 +3028,9 @@ __metadata:
     "@jupyterlab/terminal": ^4.2.0
     "@jupyterlab/terminal-extension": ^4.2.0
     "@jupyterlab/testutils": ^4.0.0
-    "@jupyterlite/cockle": ^0.0.4
-    "@jupyterlite/contents": ^0.3.0 || ^0.4.0-beta.0
-    "@jupyterlite/server": ^0.3.0 || ^0.4.0-beta.0
+    "@jupyterlite/cockle": ^0.0.5
+    "@jupyterlite/contents": ^0.4.0
+    "@jupyterlite/server": ^0.4.0
     "@lumino/coreutils": ^2.1.2
     "@types/jest": ^29.2.0
     "@types/json-schema": ^7.0.11
@@ -3076,13 +3062,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@jupyterlite/translation@npm:^0.3.0":
-  version: 0.3.0
-  resolution: "@jupyterlite/translation@npm:0.3.0"
+"@jupyterlite/translation@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "@jupyterlite/translation@npm:0.4.0"
   dependencies:
-    "@jupyterlab/coreutils": ~6.1.5
+    "@jupyterlab/coreutils": ~6.2.4
     "@lumino/coreutils": ^2.1.2
-  checksum: 4ad7301f66cea0d1f82ea6a9d748321b0b3be8d238383b9aeb160427695a71a941042fddfd3d9052f19508219a250d8c59affaf76c260f5e8db095a11d5b66dc
+  checksum: e46c1a5333a91a60c9783e3632bb468acb301b2e0630ae6b1e5713cb4fc7ed86566be29b91932d07269782d4590a8935a795b87b4b2004bc773d4c48b1698575
   languageName: node
   linkType: hard
 
@@ -3250,7 +3236,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lumino/application@npm:^2.3.0, @lumino/application@npm:^2.3.1":
+"@lumino/application@npm:^2.3.1":
   version: 2.4.0
   resolution: "@lumino/application@npm:2.4.0"
   dependencies:
@@ -3270,7 +3256,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lumino/commands@npm:^2.2.0, @lumino/commands@npm:^2.3.0, @lumino/commands@npm:^2.3.1":
+"@lumino/commands@npm:^2.3.0, @lumino/commands@npm:^2.3.1":
   version: 2.3.1
   resolution: "@lumino/commands@npm:2.3.1"
   dependencies:


### PR DESCRIPTION
Update jupyterlite to 0.4.0 and cockle to 0.0.5. The latter requires a change when calling the `Shell` constructor.