### PR TITLE
Add config files to deploy to Vercel with the COOP / COEP headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,18 @@ Then build a new JupyterLite site:
 jupyter lite build
 ```
 
+## Deployment
+
+If you would like to deploy a JupyterLite site with the terminal extension, you will need to configure your server to add the `Cross-Origin-Embedder-Policy` and `Cross-Origin-Opener-Policy` headers.
+
+As an example, this repository deploys the JupyterLite terminal to [Vercel](https://vercel.com), using the following files:
+
+- `vercel.json`: configure the COOP / COEP server headers
+- `requirements-deploy.txt`: dependencies for the JupyterLite deployment
+- `deploy.sh`: script to deploy to Vercel, using micromamba to have full control on the Python versions and isolate the build in a virtual environment
+
+For more information, have a look at the JupyterLite documentation: https://jupyterlite.readthedocs.io/
+
 ## Contributing
 
 ### Development install

--- a/deploy.sh
+++ b/deploy.sh
@@ -2,7 +2,7 @@
 
 yum install wget -y
 
-wget -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
+wget -qO- https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
 
 export PATH="$PWD/bin:$PATH"
 export MAMBA_ROOT_PREFIX="$PWD/micromamba"

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+yum install wget -y
+
+wget -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
+
+export PATH="$PWD/bin:$PATH"
+export MAMBA_ROOT_PREFIX="$PWD/micromamba"
+
+# Initialize Micromamba shell
+./bin/micromamba shell init -s bash --no-modify-profile -p $MAMBA_ROOT_PREFIX
+
+# Source Micromamba environment directly
+eval "$(./bin/micromamba shell hook -s bash)"
+
+# Activate the Micromamba environment
+micromamba create -n jupyterenv python=3.11 -c conda-forge -y
+micromamba activate jupyterenv
+
+# install the dependencies
+python -m pip install -r requirements-deploy.txt
+
+# build the JupyterLite site
+jupyter lite --version
+jupyter lite build --output-dir dist

--- a/requirements-deploy.txt
+++ b/requirements-deploy.txt
@@ -1,0 +1,3 @@
+jupyterlab~=4.2.5
+jupyterlite-core
+jupyterlite-pyodide-kernel

--- a/requirements-deploy.txt
+++ b/requirements-deploy.txt
@@ -1,3 +1,4 @@
 jupyterlab~=4.2.5
 jupyterlite-core
 jupyterlite-pyodide-kernel
+.

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,17 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Cross-Origin-Embedder-Policy",
+          "value": "require-corp"
+        },
+        {
+          "key": "Cross-Origin-Opener-Policy",
+          "value": "same-origin"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This will make it easier to test the latest state of the terminal directly in the browser without having to set it up locally.

It will also enable preview deployments to make it easier to test changes in PRs.