### PR TITLE
Support use of em-forge wasm files in standalone JupyterLite deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,4 @@ dmypy.json
 _output/
 cockle_wasm_env/
 cockle-config.json
+.cockle_temp/

--- a/jupyterlite_terminal/add_on.py
+++ b/jupyterlite_terminal/add_on.py
@@ -20,14 +20,22 @@ class TerminalAddon(FederatedExtensionAddon):
         super().__init__(*args, **kwargs)
 
     def post_build(self, manager):
-        cockleTool = Path("node_modules") / "@jupyterlite" / "cockle" / "lib" / "tools" / "prepare_wasm.js"
+        cockleTool = Path("node_modules", "@jupyterlite", "cockle", "lib", "tools", "prepare_wasm.js")
+        if not cockleTool.is_file():
+            cockleTool = ".cockle_temp" / cockleTool
+            cmd = ["npm", "install", "--no-save", "--prefix", cockleTool.parts[0], "@jupyterlite/cockle"]
+            print("TerminalAddon:", " ".join(cmd))
+            subprocess.run(cmd, check=True)
+
         assetDir = Path(self.manager.output_dir) / "extensions" / "@jupyterlite" / "terminal" / "static" / "wasm"
 
         # Although cockle's prepare_wasm is perfectly capable of copying the wasm and associated
         # files to the asset directory, here we just get the list of required files and let the
         # add-on do the copying for consistency with other extensions.
         tempFilename = 'cockle-files.txt'
-        subprocess.run(["node", str(cockleTool), "--list", tempFilename], check=True)
+        cmd = ["node", str(cockleTool), "--list", tempFilename]
+        print("TerminalAddon:", " ".join(cmd))
+        subprocess.run(cmd, check=True)
 
         with open(tempFilename, 'r') as f:
             for source in f:


### PR DESCRIPTION
The recent changes in `cockle` to support use of Emscripten-forge wasm files in the terminal (jupyterlite/cockle#61) work fine in the `cockle` and `terminal` repositories but do not work in a standalone JupyterLite deployment as they rely on `cockle` being available locally in `node_modules`. This is a workaround to support that use case by checking if the required `cockle` file is installed locally in `node_modules` and if it is not, it installs it in a temporary directory `.cockle_temp`. This is not a good workaround as it unnecessarily installs a set of `npm` dependencies, but it is better to have such standalone deployments working than not, and we can revisit this later with a better solution.

After merging this will need a new release of the `terminal` packages so that it can be tried out in a standalone deployment.