### PR TITLE
Rename Terminals to TerminalManager

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,17 +7,17 @@ import {
   Router
 } from '@jupyterlite/server';
 
-import { ITerminals } from './tokens';
-import { Terminals } from './terminals';
+import { TerminalManager } from './manager';
+import { ITerminalManager } from './tokens';
 
 /**
  * The terminals service plugin.
  */
-const terminalsPlugin: JupyterLiteServerPlugin<ITerminals> = {
+const terminalsPlugin: JupyterLiteServerPlugin<ITerminalManager> = {
   id: '@jupyterlite/terminal:plugin',
   description: 'A terminal for JupyterLite',
   autoStart: true,
-  provides: ITerminals,
+  provides: ITerminalManager,
   activate: async (app: JupyterLiteServer) => {
     console.log(
       'JupyterLite extension @jupyterlite/terminal:plugin is activated!'
@@ -33,7 +33,7 @@ const terminalsPlugin: JupyterLiteServerPlugin<ITerminals> = {
     await terminals.ready;
     console.log('terminals ready after await:', terminals.isReady); // Ready
 
-    return new Terminals(serverSettings.wsUrl);
+    return new TerminalManager(serverSettings.wsUrl);
   }
 };
 
@@ -43,23 +43,23 @@ const terminalsPlugin: JupyterLiteServerPlugin<ITerminals> = {
 const terminalsRoutesPlugin: JupyterLiteServerPlugin<void> = {
   id: '@jupyterlite/terminal:routes-plugin',
   autoStart: true,
-  requires: [ITerminals],
-  activate: (app: JupyterLiteServer, terminals: ITerminals) => {
+  requires: [ITerminalManager],
+  activate: (app: JupyterLiteServer, terminalManager: ITerminalManager) => {
     console.log(
       'JupyterLite extension @jupyterlite/terminal:routes-plugin is activated!',
-      terminals
+      terminalManager
     );
 
     // GET /api/terminals - List the running terminals
     app.router.get('/api/terminals', async (req: Router.IRequest) => {
-      const res = await terminals.list();
+      const res = await terminalManager.running();
       // Should return last_activity for each too,
       return new Response(JSON.stringify(res));
     });
 
     // POST /api/terminals - Start a terminal
     app.router.post('/api/terminals', async (req: Router.IRequest) => {
-      const res = await terminals.startNew();
+      const res = await terminalManager.startNew();
       // Should return last_activity too.
       return new Response(JSON.stringify(res));
     });

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -5,28 +5,27 @@ import { PageConfig } from '@jupyterlab/coreutils';
 import { TerminalAPI } from '@jupyterlab/services';
 
 import { Terminal } from './terminal';
-import { ITerminals } from './tokens';
+import { ITerminalManager } from './tokens';
 
 /**
  * A class to handle requests to /api/terminals
  */
-export class Terminals implements ITerminals {
+export class TerminalManager implements ITerminalManager {
   /**
-   * Construct a new Terminals object.
+   * Construct a new TerminalManager object.
    */
   constructor(wsUrl: string) {
     this._wsUrl = wsUrl;
-    console.log('==> Terminals.constructor', this._wsUrl);
+    console.log('==> TerminalManager.constructor', this._wsUrl);
   }
 
   /**
    * List the running terminals.
    */
-  async list(): Promise<TerminalAPI.IModel[]> {
+  async running(): Promise<TerminalAPI.IModel[]> {
     const ret = [...this._terminals.values()].map(terminal => ({
       name: terminal.name
     }));
-    console.log('==> Terminals.list', ret);
     return ret;
   }
 
@@ -35,7 +34,7 @@ export class Terminals implements ITerminals {
    */
   async startNew(): Promise<TerminalAPI.IModel> {
     const name = this._nextAvailableName();
-    console.log('==> Terminals.new', name);
+    console.log('==> TerminalManager.startNew', name);
     const baseUrl = PageConfig.getBaseUrl();
     const term = new Terminal({ name, baseUrl });
     this._terminals.set(name, term);

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -8,18 +8,18 @@ import { Token } from '@lumino/coreutils';
 /**
  * The token for the Terminals service.
  */
-export const ITerminals = new Token<ITerminals>(
-  '@jupyterlite/terminal:ITerminals'
+export const ITerminalManager = new Token<ITerminalManager>(
+  '@jupyterlite/terminal:ITerminalManager'
 );
 
 /**
- * An interface for the Terminals service.
+ * An interface for the TerminalManager service.
  */
-export interface ITerminals {
+export interface ITerminalManager {
   /**
    * List the running terminals.
    */
-  list: () => Promise<TerminalAPI.IModel[]>;
+  running: () => Promise<TerminalAPI.IModel[]>;
 
   /**
    * Start a new kernel.


### PR DESCRIPTION
Rename `Terminals` to `TerminalManager` to be more consistent with the names used in JupyterLab. Also changed the name of the `list` function to `running` for consistency.