### PR TITLE
Add experimental support for registering external commands

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1,6 +1,7 @@
 import { PageConfig, URLExt } from '@jupyterlab/coreutils';
 import { ServerConnection, Terminal } from '@jupyterlab/services';
 import {
+  IExternalCommand,
   IShellManager,
   IStdinReply,
   IStdinRequest,
@@ -68,6 +69,10 @@ export class LiteTerminalAPIClient implements ILiteTerminalAPIClient {
     });
     this._shells.set(name, shell);
 
+    for (const externalCommand of this._externalCommands) {
+      shell.registerExternalCommand(externalCommand);
+    }
+
     // Hook to connect socket to shell.
     const hook = async (
       shell: Shell,
@@ -116,6 +121,10 @@ export class LiteTerminalAPIClient implements ILiteTerminalAPIClient {
     return this._models;
   }
 
+  registerExternalCommand(options: IExternalCommand.IOptions): void {
+    this._externalCommands.push(options);
+  }
+
   async shutdown(name: string): Promise<void> {
     const shell = this._shells.get(name);
     if (shell !== undefined) {
@@ -142,6 +151,7 @@ export class LiteTerminalAPIClient implements ILiteTerminalAPIClient {
   }
 
   private _browsingContextId?: string;
+  private _externalCommands: IExternalCommand.IOptions[] = [];
   private _shellManager: IShellManager;
   private _shells = new Map<string, Shell>();
 }

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -1,5 +1,9 @@
 import { Terminal } from '@jupyterlab/services';
-import { IStdinReply, IStdinRequest } from '@jupyterlite/cockle';
+import {
+  IExternalCommand,
+  IStdinReply,
+  IStdinRequest
+} from '@jupyterlite/cockle';
 import { Token } from '@lumino/coreutils';
 
 export const ILiteTerminalAPIClient = new Token<ILiteTerminalAPIClient>(
@@ -16,4 +20,9 @@ export interface ILiteTerminalAPIClient extends Terminal.ITerminalAPIClient {
    * Function that handles stdin requests received from service worker.
    */
   handleStdin(request: IStdinRequest): Promise<IStdinReply>;
+
+  /**
+   * Register an external command that will be available in all terminals.
+   */
+  registerExternalCommand(options: IExternalCommand.IOptions): void;
 }


### PR DESCRIPTION
This adds experimental support for registering external commands. These are TypeScript commands that run in the main UI thread rather than the `cockle` webworker, and will be used to allow the terminal to access JupyterLite internals at runtime (settings, commands, kernels, etc).

The API here is to call `ILiteTerminalAPIClient.registerExternalCommand` and this can be done from new `JupyterFrontEndPlugin`s either in this repo or separate extension repos. All external commands registered this way will be available in all terminals opened.

There are no tests added for this, I need an example of a real useful external command first.

Note it is labelled as experimental as the API will change.