### PR TITLE
Update to cockle 0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A terminal for JupyterLite.
 
 ## Requirements
 
-- JupyterLite >= 0.4.0
+- JupyterLite >= 0.6.0
 
 ## Install
 
@@ -45,18 +45,6 @@ Then build a new JupyterLite site:
 ```bash
 jupyter lite build
 ```
-
-## Deployment
-
-If you would like to deploy a JupyterLite site with the terminal extension, you will need to configure your server to add the `Cross-Origin-Embedder-Policy` and `Cross-Origin-Opener-Policy` headers.
-
-As an example, this repository deploys the JupyterLite terminal to [Vercel](https://vercel.com), using the following files:
-
-- `vercel.json`: configure the COOP / COEP server headers
-- `deploy/requirements-deploy.txt`: dependencies for the JupyterLite deployment
-- `deploy/deploy.sh`: script to deploy to Vercel, using micromamba to have full control on the Python versions and isolate the build in a virtual environment
-
-For more information, have a look at the JupyterLite documentation: https://jupyterlite.readthedocs.io/
 
 ## Contributing
 
@@ -98,6 +86,18 @@ jupyter lite build --contents contents
 And serve it either using:
 
 ```bash
+npx static-handler _output/
+```
+
+or:
+
+```bash
+jupyter lite serve
+```
+
+To enable use of SharedArrayBuffer rather than ServiceWorker for `stdin` you will have to configure your server to add the `Cross-Origin-Embedder-Policy` and `Cross-Origin-Opener-Policy` headers. Do this using either:
+
+```bash
 npx static-handler --cors --coop --coep --corp _output/
 ```
 
@@ -106,8 +106,6 @@ or:
 ```bash
 jupyter lite serve --LiteBuildConfig.extra_http_headers=Cross-Origin-Embedder-Policy=require-corp --LiteBuildConfig.extra_http_headers=Cross-Origin-Opener-Policy=same-origin
 ```
-
-The extra HTTP headers are require to ensure that `SharedArrayBuffer` is available.
 
 ### Packaging the extension
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "dependencies": {
         "@jupyterlab/coreutils": "^6.4.3",
         "@jupyterlab/services": "^7.4.3",
-        "@jupyterlite/cockle": "^0.1.0-a2",
+        "@jupyterlite/cockle": "^0.1.0",
         "@jupyterlite/contents": "0.6.0",
         "@jupyterlite/server": "0.6.0",
         "@lumino/coreutils": "^2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -27,9 +27,9 @@ __metadata:
   linkType: hard
 
 "@babel/compat-data@npm:^7.22.6, @babel/compat-data@npm:^7.27.2":
-  version: 7.27.3
-  resolution: "@babel/compat-data@npm:7.27.3"
-  checksum: c6087989612312de697b21e6855d087c8b7376e5cf47e05a2a990fc67318e439e117ae2d977d317e5912e0323a3da13d6aca88348ef3c1218b0c74cc58b0a0cf
+  version: 7.27.5
+  resolution: "@babel/compat-data@npm:7.27.5"
+  checksum: 8706be55f1c6e1cf85bfb3f2b3afdabba82142b339a11b62c694d07907b082d5715dfbe77fbbad891979809bdd013a0c9e2e5c3419dc8099b9fb7a45215f0f73
   languageName: node
   linkType: hard
 
@@ -57,15 +57,15 @@ __metadata:
   linkType: hard
 
 "@babel/generator@npm:^7.27.3, @babel/generator@npm:^7.7.2":
-  version: 7.27.3
-  resolution: "@babel/generator@npm:7.27.3"
+  version: 7.27.5
+  resolution: "@babel/generator@npm:7.27.5"
   dependencies:
-    "@babel/parser": ^7.27.3
+    "@babel/parser": ^7.27.5
     "@babel/types": ^7.27.3
     "@jridgewell/gen-mapping": ^0.3.5
     "@jridgewell/trace-mapping": ^0.3.25
     jsesc: ^3.0.2
-  checksum: c0b1b399ff62fa0f1903679ab2b088fd4312c33154c0ae78228094c196ecf53ce8e525b8f5e537ac3117ff9a49cdf7b3640f129114908dfadc6541853f3747a2
+  checksum: f6d3bf70f6bfbc5df263a023200728c53161d7f3ee3607bd8b2222c8568b6dd604ee490e305f0492a8225dac059ad75b4cc772b5cfd7d967e70360499d4d3701
   languageName: node
   linkType: hard
 
@@ -263,14 +263,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.23.9, @babel/parser@npm:^7.27.2, @babel/parser@npm:^7.27.3, @babel/parser@npm:^7.27.4":
-  version: 7.27.4
-  resolution: "@babel/parser@npm:7.27.4"
+"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.23.9, @babel/parser@npm:^7.27.2, @babel/parser@npm:^7.27.4, @babel/parser@npm:^7.27.5":
+  version: 7.27.5
+  resolution: "@babel/parser@npm:7.27.5"
   dependencies:
     "@babel/types": ^7.27.3
   bin:
     parser: ./bin/babel-parser.js
-  checksum: 846d26768826c79fecd0fddca34da1d3b2814afa2907b5379769e5265b15824ab2feea76c598b3db11284935bd04133b96bd5f5ca8d4c1cf2780000afd0feb68
+  checksum: 16f00a12895522c1682f1f047332010e129ba517add3a2db347a658e02f60434fc38f9105a9d6ec3fd6bfb5d1b0b70d88585c1f10e06e2b58fba29004a42d648
   languageName: node
   linkType: hard
 
@@ -601,13 +601,13 @@ __metadata:
   linkType: hard
 
 "@babel/plugin-transform-block-scoping@npm:^7.27.1":
-  version: 7.27.3
-  resolution: "@babel/plugin-transform-block-scoping@npm:7.27.3"
+  version: 7.27.5
+  resolution: "@babel/plugin-transform-block-scoping@npm:7.27.5"
   dependencies:
     "@babel/helper-plugin-utils": ^7.27.1
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 03e85d9a5578e4a22618ae9b010cdbb883b8fea100007f81e919cbd37704d6b237ce657ab9320d216c84a8212239662252d5eb60f2d45520346c8722050e1624
+  checksum: bd710674bebe2e90b1daee960523d06c958f060f439ce2eef6b157c780c0654168131d0312a06dd71c5b186ecc2a818334d16f8368bd273ab549d6230f074135
   languageName: node
   linkType: hard
 
@@ -1003,13 +1003,13 @@ __metadata:
   linkType: hard
 
 "@babel/plugin-transform-regenerator@npm:^7.27.1":
-  version: 7.27.4
-  resolution: "@babel/plugin-transform-regenerator@npm:7.27.4"
+  version: 7.27.5
+  resolution: "@babel/plugin-transform-regenerator@npm:7.27.5"
   dependencies:
     "@babel/helper-plugin-utils": ^7.27.1
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 53d2659eff4cda8cc399ce504f698f72610c3f4ac9beda1653e0177d88bbd05256ea44cc1fabc358b219e4cf77dca1e3a8076ac4428a88a6d1cf1b1c085f8a50
+  checksum: d343dbe491f2b2ef953ce990761006b8f1f9231044b3c244529d34335ba8337829e6d55cae0e4e9ec6d4952bc4875097c8776eee01119cd45529bc49e90c085f
   languageName: node
   linkType: hard
 
@@ -2638,9 +2638,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlite/cockle@npm:^0.1.0-a2":
-  version: 0.1.0-a2
-  resolution: "@jupyterlite/cockle@npm:0.1.0-a2"
+"@jupyterlite/cockle@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "@jupyterlite/cockle@npm:0.1.0"
   dependencies:
     "@lumino/coreutils": ^2.2.0
     "@lumino/disposable": ^2.1.3
@@ -2649,7 +2649,7 @@ __metadata:
     deepmerge-ts: ^7.1.4
     rimraf: ^6.0.1
     zod: ^3.23.8
-  checksum: a3383593893cfc033a42e29ef6aaaa5c3e97503c27918aab69a5d12b902d18648c0aff48443d0851ea64254571443ad9d7a3ae9b76ea6e7a55e49f5b1b8f2e51
+  checksum: 62d2eef930754074b3256cc716d864feb3f2bd7ec63266ab0c0a9e550b0c716b6bbf9a69cb3630f260150cc2b5f250e2fbb46809d7c7ccaf2aa77549173a3550
   languageName: node
   linkType: hard
 
@@ -2755,7 +2755,7 @@ __metadata:
     "@jupyterlab/coreutils": ^6.4.3
     "@jupyterlab/services": ^7.4.3
     "@jupyterlab/testutils": ^4.4.3
-    "@jupyterlite/cockle": ^0.1.0-a2
+    "@jupyterlite/cockle": ^0.1.0
     "@jupyterlite/contents": 0.6.0
     "@jupyterlite/server": 0.6.0
     "@lumino/coreutils": ^2.2.0
@@ -4423,9 +4423,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.30001718":
-  version: 1.0.30001720
-  resolution: "caniuse-lite@npm:1.0.30001720"
-  checksum: 97b9f9de842595ff9674001abb9c5bc093c03bb985d481ed97617ea48fc248bfb2cc1f1afe19da2bf20016f28793e495fa2f339e22080d8da3c9714fb7950926
+  version: 1.0.30001721
+  resolution: "caniuse-lite@npm:1.0.30001721"
+  checksum: 1f1e1f5f070f97ee83a08601709413300957be624790a8f7b3aebd5746d648e8d50be4ef9572a50281198b2f7acc63fdfc1a0bc04c23bbffba0ab4b3c69d4b76
   languageName: node
   linkType: hard
 
@@ -5083,9 +5083,9 @@ __metadata:
   linkType: hard
 
 "electron-to-chromium@npm:^1.5.160":
-  version: 1.5.162
-  resolution: "electron-to-chromium@npm:1.5.162"
-  checksum: 777bd278da53730a280166237a9458d6e00bb5c55014146d44fceb74d75fab2149b5484be6f857e3943ba0f6162618c1a028c362950730eeced6921e5c158f6a
+  version: 1.5.164
+  resolution: "electron-to-chromium@npm:1.5.164"
+  checksum: 173fbb6e21bd1cd4e9ef4614ce8fa139a94479577d2c624954fdd512a376bfb111ea474527cc40ed7d4c710e38ba7df3fde9ba3a2c8bcd34865b8a769aaa0adc
   languageName: node
   linkType: hard
 
@@ -11042,8 +11042,8 @@ __metadata:
   linkType: hard
 
 "zod@npm:^3.23.8":
-  version: 3.25.49
-  resolution: "zod@npm:3.25.49"
-  checksum: 7432d7ef54fc803fea121b20930a9d528c54d244c8c6549447b75443a3587b94745c5add5ac8550c9a77e0c7cda3ec3d6aff83e33adfc1dc9d34a266856dace8
+  version: 3.25.51
+  resolution: "zod@npm:3.25.51"
+  checksum: 37ff0e4ef274d4a5d46882d351797f609d14decae16af46692295a68a0f34f4895bd3233ce2514027d08f7a77abcc8b47d005dba0a17bfe4f7e8410f99595441
   languageName: node
   linkType: hard


### PR DESCRIPTION
Update to cockle 0.1.0 in preparation for terminal 0.2.0 which will be the first full release to support use of ServiceWorker for `stdin`.