### PR TITLE
Disable jupyterlab's terminal-manager extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ After installing `jupyterlite-core` and `jupyterlite-terminal`, create a `jupyte
 {
   "jupyter-lite-schema-version": 0,
   "jupyter-config-data": {
+    "disabledExtensions": ["@jupyterlab/services-extension:terminal-manager"],
     "terminalsAvailable": true
   }
 }

--- a/deploy/jupyter-lite.json
+++ b/deploy/jupyter-lite.json
@@ -1,6 +1,7 @@
 {
   "jupyter-lite-schema-version": 0,
   "jupyter-config-data": {
+    "disabledExtensions": ["@jupyterlab/services-extension:terminal-manager"],
     "terminalsAvailable": true
   }
 }

--- a/ui-tests/jupyter-lite.json
+++ b/ui-tests/jupyter-lite.json
@@ -2,6 +2,7 @@
   "jupyter-lite-schema-version": 0,
   "jupyter-config-data": {
     "appName": "JupyterLite terminal UI Tests",
+    "disabledExtensions": ["@jupyterlab/services-extension:terminal-manager"],
     "exposeAppInBrowser": true,
     "terminalsAvailable": true
   }


### PR DESCRIPTION
With the switch to using `TerminalAPIClient` is hasn't been necessary to disable JupyterLab's default terminal manager extension, at least in local test deployments. But there are some deployments in which this causes a problem, so here disabling the extension.