### PR TITLE
Allow for JupyterLite 0.7 pre-releases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "jupyterlite-core>=0.6,<0.7"
+    "jupyterlite-core>=0.6,<0.8.0a0"
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 


### PR DESCRIPTION
There is currently to breaking change that should impact the terminal, so it would be great if the terminal could be usable with the JupyterLite 0.7 pre-releases.