### PR TITLE
Run CI on earliest and latest supported jupyterlite-core

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,12 +119,12 @@ jobs:
         name: extension-artifacts
 
     - name: Pre-install minimum jupyterlite-core
-      if: ${{ matrix.lite-version }} == "min"
+      if: ${{ matrix.lite-version == "min" }}
       run: |
         python -m pip install ${MIN_LITE_VERSION}
 
     - name: Pre-install maximum jupyterlite-core
-      if: ${{ matrix.lite-version }} == "max"
+      if: ${{ matrix.lite-version == "max" }}
       run: |
         python -m pip install ${MAX_LITE_VERSION}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Build and Test
 
 on:
   push:
@@ -20,6 +20,7 @@ env:
 
 jobs:
   build:
+    name: Build and upload wheel
     runs-on: ubuntu-latest
 
     steps:
@@ -67,6 +68,7 @@ jobs:
         if-no-files-found: error
 
   test_isolated:
+    name: Test isolated
     needs: build
     runs-on: ubuntu-latest
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ env:
   # Min and max limits of jupyterlite-core versions that this should work on.
   # Changes here should be synchronised with pyproject.toml dependencies section.
   MIN_LITE_VERSION: jupyterlite-core==0.6.0
-  MAX_LITE_VERSION: --pre jupyterlite-core<0.8.0a0
+  MAX_LITE_VERSION: --pre jupyterlite-core<0.8.0
 
   LAB_VERSION: jupyterlab>=4.0.0,<5
 
@@ -51,6 +51,10 @@ jobs:
 
         jupyter labextension list
         jupyter labextension list 2>&1 | grep -ie "@jupyterlite/terminal.*OK"
+
+    - name: List installed packages
+      run: |
+        python -m pip list
 
     - name: Package the extension
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  # Min and max limits of jupyterlite-core versions that this should work on.
+  # Changes here should be synchronised with pyproject.toml dependencies section.
+  MIN_LITE_VERSION: jupyterlite-core==0.6.0
+  MAX_LITE_VERSION: --pre jupyterlite-core<0.8.0a0
+
+  LAB_VERSION: jupyterlab>=4.0.0,<5
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -22,7 +30,7 @@ jobs:
       uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
     - name: Install dependencies
-      run: python -m pip install -U "jupyterlab>=4.0.0,<5"
+      run: python -m pip install -U ${LAB_VERSION}
 
     - name: Lint the extension
       run: |
@@ -68,9 +76,11 @@ jobs:
       with:
         python-version: '3.9'
         architecture: 'x64'
+
     - uses: actions/download-artifact@v4
       with:
         name: extension-artifacts
+
     - name: Install and Test
       run: |
         set -eux
@@ -78,15 +88,20 @@ jobs:
         sudo rm -rf $(which node)
         sudo rm -rf $(which node)
 
-        pip install "jupyterlab>=4.0.0,<5" jupyterlite_terminal*.whl
+        pip install ${LAB_VERSION} jupyterlite_terminal*.whl
 
         jupyter labextension list
         jupyter labextension list 2>&1 | grep -ie "@jupyterlite/terminal.*OK"
 
   integration-tests:
-    name: Integration tests
+    name: Integration tests ${{ matrix.lite-version}}
     needs: build
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        lite-version: ["min", "normal", "max"]
 
     env:
       PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/pw-browsers
@@ -103,10 +118,24 @@ jobs:
       with:
         name: extension-artifacts
 
+    - name: Pre-install minimum jupyterlite-core
+      if: ${{ matrix.lite-version }} == "min"
+      run: |
+        python -m pip install ${MIN_LITE_VERSION}
+
+    - name: Pre-install maximum jupyterlite-core
+      if: ${{ matrix.lite-version }} == "max"
+      run: |
+        python -m pip install ${MAX_LITE_VERSION}
+
     - name: Install the extension
       run: |
         set -eux
-        python -m pip install "jupyterlite-core>=0.6,<0.7" "jupyterlab>=4,<5" jupyterlite_terminal*.whl
+        python -m pip install jupyterlite_terminal*.whl ${LAB_VERSION}
+
+    - name: List installed packages
+      run: |
+        python -m pip list
 
     - name: Micromamba needed for cockle_wasm_env
       uses: mamba-org/setup-micromamba@main
@@ -142,8 +171,8 @@ jobs:
       with:
         name: jupyterlite_terminal-playwright-tests
         path: |
-          ui-tests/test-results
-          ui-tests/playwright-report
+          ui-tests/test-results_${{ matrix.lite-version}}
+          ui-tests/playwright-report_${{ matrix.lite-version}}
 
   check_links:
     name: Check Links

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        lite-version: ["min", "normal", "max"]
+        lite-version: ['min', 'normal', 'max']
 
     env:
       PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/pw-browsers
@@ -119,12 +119,12 @@ jobs:
         name: extension-artifacts
 
     - name: Pre-install minimum jupyterlite-core
-      if: ${{ matrix.lite-version == "min" }}
+      if: ${{ matrix.lite-version == 'min' }}
       run: |
         python -m pip install ${MIN_LITE_VERSION}
 
     - name: Pre-install maximum jupyterlite-core
-      if: ${{ matrix.lite-version == "max" }}
+      if: ${{ matrix.lite-version == 'max' }}
       run: |
         python -m pip install ${MAX_LITE_VERSION}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,10 @@ jobs:
           # install a dev version of the terminal extension
           python -m pip install .
 
+      - name: List installed packages
+        run: |
+        python -m pip list
+
       - name: Micromamba needed for cockle_wasm_env
         uses: mamba-org/setup-micromamba@main
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   build:
+    name: Build for deployment
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -41,6 +42,7 @@ jobs:
           path: ./deploy/dist
 
   deploy:
+    name: Deploy to github pages
     needs: build
     if: github.ref == 'refs/heads/main'
     permissions:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
+    # Changes here should be synchronised with .github/workflows/build.yml
     "jupyterlite-core>=0.6,<0.8.0a0"
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 dependencies = [
     # Changes here should be synchronised with .github/workflows/build.yml
-    "jupyterlite-core>=0.6,<0.8.0a0"
+    "jupyterlite-core>=0.6,<0.8.0"
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 


### PR DESCRIPTION
Change CI to test on the earliest and latest supported `jupyterlite-core`. Still building the wheel once, but then run the integration tests on:

- "min": Minimum jupyterlite-core, i.e. the first full release that this should work on.
- "normal": The latest full release, the same as the wheel is built on.
- "max": Maximum pre-release that this should work on. Could be the same as "normal" if there have been no new pre-releases since the latest full release.