### PR TITLE
Allow building against jupyterlite 0.7.0 alpha

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,13 +59,13 @@
         "watch:labextension": "jupyter labextension watch ."
     },
     "dependencies": {
-        "@jupyterlab/apputils": "^4.5.3",
-        "@jupyterlab/coreutils": "^6.4.3",
-        "@jupyterlab/services": "^7.4.3",
-        "@jupyterlab/settingregistry": "^4.4.3",
+        "@jupyterlab/apputils": "^4.5.3 || ^4.6.0-alpha.3",
+        "@jupyterlab/coreutils": "^6.4.3 || ^6.5.0-alpha.3",
+        "@jupyterlab/services": "^7.4.3 || ^7.5.0-alpha.3",
+        "@jupyterlab/settingregistry": "^4.4.3 || ^4.5.0-alpha.3",
         "@jupyterlite/cockle": "^1.0.0",
-        "@jupyterlite/contents": "^0.6.0",
-        "@jupyterlite/server": "^0.6.0",
+        "@jupyterlite/contents": "^0.6.0 || ^0.7.0-alpha.5",
+        "@jupyterlite/server": "^0.6.0 || ^0.7.0-alpha.5",
         "@lumino/coreutils": "^2.2.0",
         "mock-socket": "^9.3.1"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2023,7 +2023,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyter/ydoc@npm:^3.0.4":
+"@jupyter/ydoc@npm:^3.0.4, @jupyter/ydoc@npm:^3.1.0":
   version: 3.1.0
   resolution: "@jupyter/ydoc@npm:3.1.0"
   dependencies:
@@ -2065,7 +2065,36 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/apputils@npm:^4.5.3, @jupyterlab/apputils@npm:^4.5.5":
+"@jupyterlab/apputils@npm:^4.5.3 || ^4.6.0-alpha.3":
+  version: 4.6.0-alpha.3
+  resolution: "@jupyterlab/apputils@npm:4.6.0-alpha.3"
+  dependencies:
+    "@jupyterlab/coreutils": ^6.5.0-alpha.3
+    "@jupyterlab/observables": ^5.5.0-alpha.3
+    "@jupyterlab/rendermime-interfaces": ^3.13.0-alpha.3
+    "@jupyterlab/services": ^7.5.0-alpha.3
+    "@jupyterlab/settingregistry": ^4.5.0-alpha.3
+    "@jupyterlab/statedb": ^4.5.0-alpha.3
+    "@jupyterlab/statusbar": ^4.5.0-alpha.3
+    "@jupyterlab/translation": ^4.5.0-alpha.3
+    "@jupyterlab/ui-components": ^4.5.0-alpha.3
+    "@lumino/algorithm": ^2.0.3
+    "@lumino/commands": ^2.3.2
+    "@lumino/coreutils": ^2.2.1
+    "@lumino/disposable": ^2.1.4
+    "@lumino/domutils": ^2.0.3
+    "@lumino/messaging": ^2.0.3
+    "@lumino/signaling": ^2.1.4
+    "@lumino/virtualdom": ^2.0.3
+    "@lumino/widgets": ^2.7.1
+    "@types/react": ^18.0.26
+    react: ^18.2.0
+    sanitize-html: ~2.12.1
+  checksum: 8d2af926cd3031268a370a07cea8ca488510fe0df280c6135103b5e5b027eb4d4de87e5006ff1a296afe627eddaeba43c2f43831ca1ff44da3cc8a3966eba108
+  languageName: node
+  linkType: hard
+
+"@jupyterlab/apputils@npm:^4.5.5":
   version: 4.5.5
   resolution: "@jupyterlab/apputils@npm:4.5.5"
   dependencies:
@@ -2251,7 +2280,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/coreutils@npm:^6.4.3, @jupyterlab/coreutils@npm:^6.4.5, @jupyterlab/coreutils@npm:~6.4.4":
+"@jupyterlab/coreutils@npm:^6.4.3 || ^6.5.0-alpha.3, @jupyterlab/coreutils@npm:^6.5.0-alpha.3, @jupyterlab/coreutils@npm:~6.5.0-alpha.3":
+  version: 6.5.0-alpha.3
+  resolution: "@jupyterlab/coreutils@npm:6.5.0-alpha.3"
+  dependencies:
+    "@lumino/coreutils": ^2.2.1
+    "@lumino/disposable": ^2.1.4
+    "@lumino/signaling": ^2.1.4
+    minimist: ~1.2.0
+    path-browserify: ^1.0.0
+    url-parse: ~1.5.4
+  checksum: 041fd93bd2311f05c0fcb910d30708b7535c64b96a634b02288b89d7cae75a487714a78e466af0f5d8a73a53bfc02750683cae8229b6f2735cd2ec19ff17dcb7
+  languageName: node
+  linkType: hard
+
+"@jupyterlab/coreutils@npm:^6.4.5":
   version: 6.4.5
   resolution: "@jupyterlab/coreutils@npm:6.4.5"
   dependencies:
@@ -2387,12 +2430,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/nbformat@npm:^3.0.0 || ^4.0.0-alpha.21 || ^4.0.0, @jupyterlab/nbformat@npm:^4.4.5, @jupyterlab/nbformat@npm:~4.4.4":
+"@jupyterlab/nbformat@npm:^3.0.0 || ^4.0.0-alpha.21 || ^4.0.0, @jupyterlab/nbformat@npm:^4.4.5":
   version: 4.4.5
   resolution: "@jupyterlab/nbformat@npm:4.4.5"
   dependencies:
     "@lumino/coreutils": ^2.2.1
   checksum: 8f42dd689693a70b196e34ad68c915b9217a77355428b5344f545f4d89373b302deb5a6b31426ee7cc78a77ab83db9e7714ef7c23f9cb35ea7ffbc120f98aef6
+  languageName: node
+  linkType: hard
+
+"@jupyterlab/nbformat@npm:^4.5.0-alpha.3, @jupyterlab/nbformat@npm:~4.5.0-alpha.3":
+  version: 4.5.0-alpha.3
+  resolution: "@jupyterlab/nbformat@npm:4.5.0-alpha.3"
+  dependencies:
+    "@lumino/coreutils": ^2.2.1
+  checksum: 24a06aed9f9412fef639c16fe573f8e38bdaf5624bad6dcc5b036644aec078fed07b774872e1a0ac3d2c7007975217014308f4c1ae2f2ac578ee72bc70be1f4f
   languageName: node
   linkType: hard
 
@@ -2434,7 +2486,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/observables@npm:^5.4.5, @jupyterlab/observables@npm:~5.4.4":
+"@jupyterlab/observables@npm:^5.4.5":
   version: 5.4.5
   resolution: "@jupyterlab/observables@npm:5.4.5"
   dependencies:
@@ -2444,6 +2496,32 @@ __metadata:
     "@lumino/messaging": ^2.0.3
     "@lumino/signaling": ^2.1.4
   checksum: 299e257c73def84d980b15c6651908280c44d7130b8666799b168558bd83d9f3838d54e090a5b6d96db43a0150d21279aebb814018f5ce8518e5a8d04dccc3c3
+  languageName: node
+  linkType: hard
+
+"@jupyterlab/observables@npm:^5.5.0-alpha.3":
+  version: 5.5.0-alpha.3
+  resolution: "@jupyterlab/observables@npm:5.5.0-alpha.3"
+  dependencies:
+    "@lumino/algorithm": ^2.0.3
+    "@lumino/coreutils": ^2.2.1
+    "@lumino/disposable": ^2.1.4
+    "@lumino/messaging": ^2.0.3
+    "@lumino/signaling": ^2.1.4
+  checksum: 233078a1358e764a7262d736338d10c63b896ec7cb80937ee0db697496fd5910ea6823389432bdbe3509999a1f1060148821b363e279da34a8ba5a2597ad9810
+  languageName: node
+  linkType: hard
+
+"@jupyterlab/observables@npm:~4.5.0-alpha.3":
+  version: 4.5.3
+  resolution: "@jupyterlab/observables@npm:4.5.3"
+  dependencies:
+    "@lumino/algorithm": ^1.9.0
+    "@lumino/coreutils": ^1.11.0
+    "@lumino/disposable": ^1.10.0
+    "@lumino/messaging": ^1.10.0
+    "@lumino/signaling": ^1.10.0
+  checksum: f68c837faf534c41fd4a9c5e3bbbd22e538b35b073c3713cfd0fe4bb6e44e43b95e87c153a72436e4c7c5493c56f552011c7280676cec3a19c6aaa856dec47fe
   languageName: node
   linkType: hard
 
@@ -2479,6 +2557,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jupyterlab/rendermime-interfaces@npm:^3.13.0-alpha.3":
+  version: 3.13.0-alpha.3
+  resolution: "@jupyterlab/rendermime-interfaces@npm:3.13.0-alpha.3"
+  dependencies:
+    "@lumino/coreutils": ^1.11.0 || ^2.2.1
+    "@lumino/widgets": ^1.37.2 || ^2.7.1
+  checksum: eefec426e1354f462a2aca362cb6dfd4dc4e7744fdc4f941ec8c76e10134614b0638cfd7574780c2ec0eef879e8dc6e3a7281a7fc8bd34c66558796c1dd719b1
+  languageName: node
+  linkType: hard
+
 "@jupyterlab/rendermime@npm:^4.4.5":
   version: 4.4.5
   resolution: "@jupyterlab/rendermime@npm:4.4.5"
@@ -2499,7 +2587,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/services@npm:^7.4.3, @jupyterlab/services@npm:^7.4.5, @jupyterlab/services@npm:~7.4.4":
+"@jupyterlab/services@npm:^7.4.3 || ^7.5.0-alpha.3, @jupyterlab/services@npm:^7.5.0-alpha.3, @jupyterlab/services@npm:~7.5.0-alpha.3":
+  version: 7.5.0-alpha.3
+  resolution: "@jupyterlab/services@npm:7.5.0-alpha.3"
+  dependencies:
+    "@jupyter/ydoc": ^3.1.0
+    "@jupyterlab/coreutils": ^6.5.0-alpha.3
+    "@jupyterlab/nbformat": ^4.5.0-alpha.3
+    "@jupyterlab/settingregistry": ^4.5.0-alpha.3
+    "@jupyterlab/statedb": ^4.5.0-alpha.3
+    "@lumino/coreutils": ^2.2.1
+    "@lumino/disposable": ^2.1.4
+    "@lumino/polling": ^2.1.4
+    "@lumino/properties": ^2.0.3
+    "@lumino/signaling": ^2.1.4
+    ws: ^8.11.0
+  checksum: c279b082f73f895d8ba0b3f48b58570b4fafe5964747b923fd8603d992337fa37b9144b33ac68e681ac5485284ea80366f88065ae34b2a586c94c9a5acda2f91
+  languageName: node
+  linkType: hard
+
+"@jupyterlab/services@npm:^7.4.5":
   version: 7.4.5
   resolution: "@jupyterlab/services@npm:7.4.5"
   dependencies:
@@ -2518,7 +2625,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/settingregistry@npm:^4.4.3, @jupyterlab/settingregistry@npm:^4.4.5, @jupyterlab/settingregistry@npm:~4.4.4":
+"@jupyterlab/settingregistry@npm:^4.4.3 || ^4.5.0-alpha.3, @jupyterlab/settingregistry@npm:^4.5.0-alpha.3, @jupyterlab/settingregistry@npm:~4.5.0-alpha.3":
+  version: 4.5.0-alpha.3
+  resolution: "@jupyterlab/settingregistry@npm:4.5.0-alpha.3"
+  dependencies:
+    "@jupyterlab/nbformat": ^4.5.0-alpha.3
+    "@jupyterlab/statedb": ^4.5.0-alpha.3
+    "@lumino/commands": ^2.3.2
+    "@lumino/coreutils": ^2.2.1
+    "@lumino/disposable": ^2.1.4
+    "@lumino/signaling": ^2.1.4
+    "@rjsf/utils": ^5.13.4
+    ajv: ^8.12.0
+    json5: ^2.2.3
+  peerDependencies:
+    react: ">=16"
+  checksum: e9fe4b02cf1df495ed26d28dc367ed2e4972ff341f8e78f06663706982d6a4284766c486b417acdb105f4114f9935ef2b713d670dc31bb91dfe6e3ddd3829a86
+  languageName: node
+  linkType: hard
+
+"@jupyterlab/settingregistry@npm:^4.4.5":
   version: 4.4.5
   resolution: "@jupyterlab/settingregistry@npm:4.4.5"
   dependencies:
@@ -2537,7 +2663,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/statedb@npm:^4.4.5, @jupyterlab/statedb@npm:~4.4.4":
+"@jupyterlab/statedb@npm:^4.4.5":
   version: 4.4.5
   resolution: "@jupyterlab/statedb@npm:4.4.5"
   dependencies:
@@ -2547,6 +2673,19 @@ __metadata:
     "@lumino/properties": ^2.0.3
     "@lumino/signaling": ^2.1.4
   checksum: eab9e3359d060aac929d3c0aa62bbfa077d2725c8ffbaa5b6eba5eae86da0f8d12d2e82f8802d16a370a159bb1f9d7edb6ec50c64abfd237fb7216672b1fc9f2
+  languageName: node
+  linkType: hard
+
+"@jupyterlab/statedb@npm:^4.5.0-alpha.3, @jupyterlab/statedb@npm:~4.5.0-alpha.3":
+  version: 4.5.0-alpha.3
+  resolution: "@jupyterlab/statedb@npm:4.5.0-alpha.3"
+  dependencies:
+    "@lumino/commands": ^2.3.2
+    "@lumino/coreutils": ^2.2.1
+    "@lumino/disposable": ^2.1.4
+    "@lumino/properties": ^2.0.3
+    "@lumino/signaling": ^2.1.4
+  checksum: f388e9e43be16b3e6964a9534e488e82ee012bcf2d92558390b1fb3df9a041eb24adb62f24921a738702c924aef2d4fc11edbe8033f00265965a09e7fbd08dd0
   languageName: node
   linkType: hard
 
@@ -2563,6 +2702,22 @@ __metadata:
     "@lumino/widgets": ^2.7.1
     react: ^18.2.0
   checksum: bf12f47a0a6d74191e1f1947dd1db4490de2e0287a212d50fd4d32c8169bdccb930f0400d9a79815c23d5136024226f9455511557d48efd594a7a273865db691
+  languageName: node
+  linkType: hard
+
+"@jupyterlab/statusbar@npm:^4.5.0-alpha.3":
+  version: 4.5.0-alpha.3
+  resolution: "@jupyterlab/statusbar@npm:4.5.0-alpha.3"
+  dependencies:
+    "@jupyterlab/ui-components": ^4.5.0-alpha.3
+    "@lumino/algorithm": ^2.0.3
+    "@lumino/coreutils": ^2.2.1
+    "@lumino/disposable": ^2.1.4
+    "@lumino/messaging": ^2.0.3
+    "@lumino/signaling": ^2.1.4
+    "@lumino/widgets": ^2.7.1
+    react: ^18.2.0
+  checksum: 6138f2b57e9c7a80834fcbfe1cac374c660a0d59078d352772002e0b8954a194ffb99ec533ca45577038b15d7a855e07667aa5c625af718c6f1db48985af3c30
   languageName: node
   linkType: hard
 
@@ -2638,6 +2793,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jupyterlab/translation@npm:^4.5.0-alpha.3":
+  version: 4.5.0-alpha.3
+  resolution: "@jupyterlab/translation@npm:4.5.0-alpha.3"
+  dependencies:
+    "@jupyterlab/coreutils": ^6.5.0-alpha.3
+    "@jupyterlab/rendermime-interfaces": ^3.13.0-alpha.3
+    "@jupyterlab/services": ^7.5.0-alpha.3
+    "@jupyterlab/statedb": ^4.5.0-alpha.3
+    "@lumino/coreutils": ^2.2.1
+  checksum: 617c7e4ddf81ae542c0c068bce7529218f9964804fabf7622bb09cf229a698844ea7f030db0b9a4c3d4cde673e1c89986fbd620f089b4d5152d2080b66057fc5
+  languageName: node
+  linkType: hard
+
 "@jupyterlab/ui-components@npm:^4.4.5":
   version: 4.4.5
   resolution: "@jupyterlab/ui-components@npm:4.4.5"
@@ -2669,6 +2837,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jupyterlab/ui-components@npm:^4.5.0-alpha.3":
+  version: 4.5.0-alpha.3
+  resolution: "@jupyterlab/ui-components@npm:4.5.0-alpha.3"
+  dependencies:
+    "@jupyter/react-components": ^0.16.6
+    "@jupyter/web-components": ^0.16.6
+    "@jupyterlab/coreutils": ^6.5.0-alpha.3
+    "@jupyterlab/observables": ^5.5.0-alpha.3
+    "@jupyterlab/rendermime-interfaces": ^3.13.0-alpha.3
+    "@jupyterlab/translation": ^4.5.0-alpha.3
+    "@lumino/algorithm": ^2.0.3
+    "@lumino/commands": ^2.3.2
+    "@lumino/coreutils": ^2.2.1
+    "@lumino/disposable": ^2.1.4
+    "@lumino/messaging": ^2.0.3
+    "@lumino/polling": ^2.1.4
+    "@lumino/properties": ^2.0.3
+    "@lumino/signaling": ^2.1.4
+    "@lumino/virtualdom": ^2.0.3
+    "@lumino/widgets": ^2.7.1
+    "@rjsf/core": ^5.13.4
+    "@rjsf/utils": ^5.13.4
+    react: ^18.2.0
+    react-dom: ^18.2.0
+    typestyle: ^2.0.4
+  peerDependencies:
+    react: ^18.2.0
+  checksum: 7ff67261d69288bd0490a3cc8f4c26c6a79fca2c398aebcd020356424bb353574eee91b3d2bfa10a03bc887caa52e0f0d52d8cd69d06b12660273cf22241b556
+  languageName: node
+  linkType: hard
+
 "@jupyterlite/cockle@npm:^1.0.0":
   version: 1.0.0
   resolution: "@jupyterlite/cockle@npm:1.0.0"
@@ -2684,97 +2883,97 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlite/contents@npm:^0.6.0, @jupyterlite/contents@npm:^0.6.3":
-  version: 0.6.3
-  resolution: "@jupyterlite/contents@npm:0.6.3"
+"@jupyterlite/contents@npm:^0.6.0 || ^0.7.0-alpha.5, @jupyterlite/contents@npm:^0.7.0-alpha.5":
+  version: 0.7.0-alpha.5
+  resolution: "@jupyterlite/contents@npm:0.7.0-alpha.5"
   dependencies:
-    "@jupyterlab/nbformat": ~4.4.4
-    "@jupyterlab/services": ~7.4.4
-    "@jupyterlite/localforage": ^0.6.3
+    "@jupyterlab/nbformat": ~4.5.0-alpha.3
+    "@jupyterlab/services": ~7.5.0-alpha.3
+    "@jupyterlite/localforage": ^0.7.0-alpha.5
     "@lumino/coreutils": ^2.2.1
     "@types/emscripten": ^1.39.6
     localforage: ^1.9.0
     mime: ^3.0.0
-  checksum: a638d298d5e61e5c100dce960acd71239d25cccf77d2bbd4b8b5abe3b9544f1a003421e7049d645baa97f45eb917d2b9b4b024f437285b8e8d72af66da5048ce
+  checksum: 5c14d95b778e73c62f4f7ead22ad3d43999daeeb14546f2f8dffa7737ab233e86d6018c56c825c8bfeab13e8d475d0b41b0bcfdef6708a09594857881f9d6d63
   languageName: node
   linkType: hard
 
-"@jupyterlite/kernel@npm:^0.6.3":
-  version: 0.6.3
-  resolution: "@jupyterlite/kernel@npm:0.6.3"
+"@jupyterlite/kernel@npm:^0.7.0-alpha.5":
+  version: 0.7.0-alpha.5
+  resolution: "@jupyterlite/kernel@npm:0.7.0-alpha.5"
   dependencies:
-    "@jupyterlab/coreutils": ~6.4.4
-    "@jupyterlab/observables": ~5.4.4
-    "@jupyterlab/services": ~7.4.4
+    "@jupyterlab/coreutils": ~6.5.0-alpha.3
+    "@jupyterlab/observables": ~4.5.0-alpha.3
+    "@jupyterlab/services": ~7.5.0-alpha.3
     "@lumino/coreutils": ^2.2.1
     "@lumino/disposable": ^2.1.4
     "@lumino/signaling": ^2.1.4
     async-mutex: ^0.3.1
     comlink: ^4.3.1
     mock-socket: ^9.3.1
-  checksum: bb6813876a5a8248b861aefeb666f1c391dd56c760d1cee7195a7b07975398cc83892abf67ec045fc08ba4ca82798ab765aee5703b563f47061fc0dc95a79574
+  checksum: 22aba1280ddade398138070a759423064a18a13779813d4e425bb4be0f3687c0270d136e3c4388e0d097ba098f119b5cd0dee93d28ec49fd7c980f324365e725
   languageName: node
   linkType: hard
 
-"@jupyterlite/localforage@npm:^0.6.3":
-  version: 0.6.3
-  resolution: "@jupyterlite/localforage@npm:0.6.3"
+"@jupyterlite/localforage@npm:^0.7.0-alpha.5":
+  version: 0.7.0-alpha.5
+  resolution: "@jupyterlite/localforage@npm:0.7.0-alpha.5"
   dependencies:
-    "@jupyterlab/coreutils": ~6.4.4
+    "@jupyterlab/coreutils": ~6.5.0-alpha.3
     "@lumino/coreutils": ^2.2.1
     localforage: ^1.9.0
     localforage-memoryStorageDriver: ^0.9.2
-  checksum: 262b0be5ad6ccf27ea958339a5f97e3fa00d4090f9e36f19b1dd2bac1f7967a8b9a1cc09b5fb06b6738bd77f5f0669ca9977bded013e9b784e3cc56b1a3067d7
+  checksum: 820b62890610b9740eb1ab2871090efe3157de5ed4053a8fd3c86d6697791feacc71650e882849f443e3cc2a031fae3f292184972ea0a8aaa0f6c538d0ccd4b2
   languageName: node
   linkType: hard
 
-"@jupyterlite/server@npm:^0.6.0":
-  version: 0.6.3
-  resolution: "@jupyterlite/server@npm:0.6.3"
+"@jupyterlite/server@npm:^0.6.0 || ^0.7.0-alpha.5":
+  version: 0.7.0-alpha.5
+  resolution: "@jupyterlite/server@npm:0.7.0-alpha.5"
   dependencies:
-    "@jupyterlab/coreutils": ~6.4.4
-    "@jupyterlab/nbformat": ~4.4.4
-    "@jupyterlab/observables": ~5.4.4
-    "@jupyterlab/services": ~7.4.4
-    "@jupyterlab/settingregistry": ~4.4.4
-    "@jupyterlab/statedb": ~4.4.4
-    "@jupyterlite/contents": ^0.6.3
-    "@jupyterlite/kernel": ^0.6.3
-    "@jupyterlite/session": ^0.6.3
-    "@jupyterlite/settings": ^0.6.3
+    "@jupyterlab/coreutils": ~6.5.0-alpha.3
+    "@jupyterlab/nbformat": ~4.5.0-alpha.3
+    "@jupyterlab/observables": ~4.5.0-alpha.3
+    "@jupyterlab/services": ~7.5.0-alpha.3
+    "@jupyterlab/settingregistry": ~4.5.0-alpha.3
+    "@jupyterlab/statedb": ~4.5.0-alpha.3
+    "@jupyterlite/contents": ^0.7.0-alpha.5
+    "@jupyterlite/kernel": ^0.7.0-alpha.5
+    "@jupyterlite/session": ^0.7.0-alpha.5
+    "@jupyterlite/settings": ^0.7.0-alpha.5
     "@lumino/application": ^2.4.4
     "@lumino/coreutils": ^2.2.1
     "@lumino/signaling": ^2.1.4
     "@types/emscripten": ^1.39.6
     mock-socket: ^9.3.1
-  checksum: 65f64e892bbfb725e655bbe3bd25044987304a0488abd0013f79a896017df80d8a37de195cde7b927f505ff39887bd592c4c15d036fa5ec917b206d6ef1403dd
+  checksum: 79349bf070849ab8499a67134ae99ae2d2292ca4cbc35ed21e3deb094289bcb4dc09c77c9fd76b73e9ba4337c611ee985adfeefdfeac7737bb4a5f3f834a3d3f
   languageName: node
   linkType: hard
 
-"@jupyterlite/session@npm:^0.6.3":
-  version: 0.6.3
-  resolution: "@jupyterlite/session@npm:0.6.3"
+"@jupyterlite/session@npm:^0.7.0-alpha.5":
+  version: 0.7.0-alpha.5
+  resolution: "@jupyterlite/session@npm:0.7.0-alpha.5"
   dependencies:
-    "@jupyterlab/coreutils": ~6.4.4
-    "@jupyterlab/services": ~7.4.4
-    "@jupyterlite/kernel": ^0.6.3
+    "@jupyterlab/coreutils": ~6.5.0-alpha.3
+    "@jupyterlab/services": ~7.5.0-alpha.3
+    "@jupyterlite/kernel": ^0.7.0-alpha.5
     "@lumino/algorithm": ^2.0.3
     "@lumino/coreutils": ^2.2.1
-  checksum: abdc46ecb1ba5848037f48a8f68e9e01a3cbdd242c4fc50a8eddd1ea06e836d72f2f8d8c7d10ed4057337db06501fd299e6ee9ae4bbfd9d392885b6e6b9c8c40
+  checksum: c2952ebe12e239c6e8e63edf79101ba438b7965ed984fcd83e9ff7d15fd851018f7d376410fe5c1507db0a4731661b6b1f2e94e5c8c03b3f878acc0c12d67570
   languageName: node
   linkType: hard
 
-"@jupyterlite/settings@npm:^0.6.3":
-  version: 0.6.3
-  resolution: "@jupyterlite/settings@npm:0.6.3"
+"@jupyterlite/settings@npm:^0.7.0-alpha.5":
+  version: 0.7.0-alpha.5
+  resolution: "@jupyterlite/settings@npm:0.7.0-alpha.5"
   dependencies:
-    "@jupyterlab/coreutils": ~6.4.4
-    "@jupyterlab/settingregistry": ~4.4.4
-    "@jupyterlite/localforage": ^0.6.3
+    "@jupyterlab/coreutils": ~6.5.0-alpha.3
+    "@jupyterlab/settingregistry": ~4.5.0-alpha.3
+    "@jupyterlite/localforage": ^0.7.0-alpha.5
     "@lumino/coreutils": ^2.2.1
     json5: ^2.2.0
     localforage: ^1.9.0
-  checksum: 541986ffe90428adb50fa6e4ff22153f8f527fa2b8ce639dbced4ab74dea087829b6794f09370baa78a13ea7906cfb867ab69c3fb361f00a805659dfd56f9313
+  checksum: ac4187f89922fcfae1dde07cff51edaff09fd4c381ba7b9ab62611d0c2974035c407f22cc28f65a1771cd038583f9d1df0f67d05ee1c06bad9a6ccf5696d6a5b
   languageName: node
   linkType: hard
 
@@ -2782,15 +2981,15 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlite/terminal@workspace:."
   dependencies:
-    "@jupyterlab/apputils": ^4.5.3
+    "@jupyterlab/apputils": ^4.5.3 || ^4.6.0-alpha.3
     "@jupyterlab/builder": ^4.4.3
-    "@jupyterlab/coreutils": ^6.4.3
-    "@jupyterlab/services": ^7.4.3
-    "@jupyterlab/settingregistry": ^4.4.3
+    "@jupyterlab/coreutils": ^6.4.3 || ^6.5.0-alpha.3
+    "@jupyterlab/services": ^7.4.3 || ^7.5.0-alpha.3
+    "@jupyterlab/settingregistry": ^4.4.3 || ^4.5.0-alpha.3
     "@jupyterlab/testutils": ^4.4.3
     "@jupyterlite/cockle": ^1.0.0
-    "@jupyterlite/contents": ^0.6.0
-    "@jupyterlite/server": ^0.6.0
+    "@jupyterlite/contents": ^0.6.0 || ^0.7.0-alpha.5
+    "@jupyterlite/server": ^0.6.0 || ^0.7.0-alpha.5
     "@lumino/coreutils": ^2.2.0
     "@types/jest": ^29.2.0
     "@types/json-schema": ^7.0.11
@@ -2979,6 +3178,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@lumino/algorithm@npm:^1.9.0, @lumino/algorithm@npm:^1.9.2":
+  version: 1.9.2
+  resolution: "@lumino/algorithm@npm:1.9.2"
+  checksum: a89e7c63504236119634858e271db1cc649684d30ced5a6ebe2788af7c0837f1e05a6fd3047d8525eb756c42ce137f76b3688f75fd3ef915b71cd4f213dfbb96
+  languageName: node
+  linkType: hard
+
 "@lumino/algorithm@npm:^2.0.3":
   version: 2.0.3
   resolution: "@lumino/algorithm@npm:2.0.3"
@@ -2994,6 +3200,15 @@ __metadata:
     "@lumino/coreutils": ^2.2.1
     "@lumino/widgets": ^2.7.1
   checksum: 3223d145172d2d7a793e038631463fdb8c70d46f8343512d452a90f54ac70c6004462ded66edba3313038888f8271ad186feb63918620b27bde500eaa9f33d95
+  languageName: node
+  linkType: hard
+
+"@lumino/collections@npm:^1.9.3":
+  version: 1.9.3
+  resolution: "@lumino/collections@npm:1.9.3"
+  dependencies:
+    "@lumino/algorithm": ^1.9.2
+  checksum: 1c87a12743eddd6f6b593e47945a5645e2f99ad61c5192499b0745e48ee9aff263c7145541e77dfeea4c9f50bdd017fddfa47bfc60e718de4f28533ce45bf8c3
   languageName: node
   linkType: hard
 
@@ -3021,12 +3236,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@lumino/coreutils@npm:^1.11.0":
+  version: 1.12.1
+  resolution: "@lumino/coreutils@npm:1.12.1"
+  peerDependencies:
+    crypto: 1.0.1
+  checksum: 55f1b87997f8dd0af28ff23c2d4b3aa252e515b9d3bc91b350a5c6c8526ceae61b14b55dc0d8d01691c69d42974b3d559f2b49bc7ced0f474b8f5dc52b3e83ed
+  languageName: node
+  linkType: hard
+
 "@lumino/coreutils@npm:^1.11.0 || ^2.0.0, @lumino/coreutils@npm:^1.11.0 || ^2.2.1, @lumino/coreutils@npm:^2.2.0, @lumino/coreutils@npm:^2.2.1":
   version: 2.2.1
   resolution: "@lumino/coreutils@npm:2.2.1"
   dependencies:
     "@lumino/algorithm": ^2.0.3
   checksum: d08570d1ebcf6bca973ba3af0836fb19a5a7a5b24979e90aab0fb4acb245e9619a0db356a78d67f618ae565435bb2aaf7c158c5bc0ae1ef9e9f1638ebfa05484
+  languageName: node
+  linkType: hard
+
+"@lumino/disposable@npm:^1.10.0":
+  version: 1.10.4
+  resolution: "@lumino/disposable@npm:1.10.4"
+  dependencies:
+    "@lumino/algorithm": ^1.9.2
+    "@lumino/signaling": ^1.11.1
+  checksum: b53e259830f1d3231455548e6b95c9ae0f4b91e1b501980a1d0bb9708322bf5469b5cbb4e5005653d6f33b549d4bb7e58ce02226477876f51c124ea755152a33
   languageName: node
   linkType: hard
 
@@ -3063,6 +3297,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@lumino/messaging@npm:^1.10.0":
+  version: 1.10.3
+  resolution: "@lumino/messaging@npm:1.10.3"
+  dependencies:
+    "@lumino/algorithm": ^1.9.2
+    "@lumino/collections": ^1.9.3
+  checksum: 1131e80379fa9b8a9b5d3418c90e25d4be48e2c92ec711518190772f9e8845a695bef45daddd06a129168cf6f158c8ad80ae86cb245f566e9195bbd9a0843b7a
+  languageName: node
+  linkType: hard
+
 "@lumino/messaging@npm:^2.0.3":
   version: 2.0.3
   resolution: "@lumino/messaging@npm:2.0.3"
@@ -3084,6 +3328,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@lumino/properties@npm:^1.8.2":
+  version: 1.8.2
+  resolution: "@lumino/properties@npm:1.8.2"
+  checksum: 9a53709fe58d3abbc99062f0c0fda4d5f64a4c7dca509251f0f89cdcaf881fdf6172ee852dbfe70594ee34bb97255acca771a722d62e7e2150ba8cf6f7e7d15c
+  languageName: node
+  linkType: hard
+
 "@lumino/properties@npm:^2.0.3":
   version: 2.0.3
   resolution: "@lumino/properties@npm:2.0.3"
@@ -3098,6 +3349,16 @@ __metadata:
     "@lumino/algorithm": ^2.0.3
     "@lumino/coreutils": ^2.2.1
   checksum: 554a5135c8742ed3f61a4923b1f26cb29b55447ca5939df70033449cfb654a37048d7a3e2fd0932497099cd24501a3819b85cd1fdf4e76023ba0af747c171d53
+  languageName: node
+  linkType: hard
+
+"@lumino/signaling@npm:^1.10.0, @lumino/signaling@npm:^1.11.1":
+  version: 1.11.1
+  resolution: "@lumino/signaling@npm:1.11.1"
+  dependencies:
+    "@lumino/algorithm": ^1.9.2
+    "@lumino/properties": ^1.8.2
+  checksum: 3d822be705d9ba8adc46ec405a4422cd4f76ed774f94da5386a511f01df4325c3c8bfa288c9c812184c94cfd0c3ef7b1121dcc9c9489750ad6cfaa7ffb2a3a67
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
I'm making the dependency loose so that we can release this in a patch