### PR TITLE
Add infrastructure for project docs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -188,3 +188,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - uses: jupyterlab/maintainer-tools/.github/actions/check-links@v1
+        with:
+          ignore_glob: docs/*.md

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,17 @@
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: mambaforge-23.11
+  jobs:
+    pre_build:
+      - pip install -v .
+
+conda:
+  environment: docs/environment-docs.yml
+
+sphinx:
+  builder: html
+  configuration: docs/conf.py
+  fail_on_warning: true

--- a/README.md
+++ b/README.md
@@ -119,6 +119,25 @@ or:
 jupyter lite serve --LiteBuildConfig.extra_http_headers=Cross-Origin-Embedder-Policy=require-corp --LiteBuildConfig.extra_http_headers=Cross-Origin-Opener-Policy=same-origin
 ```
 
+### Building the documentation
+
+The project documentation includes a demo deployment, and is built on every PR so that the changes can be checked manually before merging. To build the documentation and demo locally use:
+
+```bash
+micromamba create -f docs/environment-docs.yml
+micromamba activate terminal-docs
+pip install -v .
+cd docs
+make html
+```
+
+To serve this locally use:
+
+```bash
+cd _build/html
+python -m http.server
+```
+
 ### Packaging the extension
 
 See [RELEASE](RELEASE.md)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/_static/terminal_logo_dark.svg
+++ b/docs/_static/terminal_logo_dark.svg
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="109.84438mm"
+   height="76.178673mm"
+   viewBox="0 0 109.84438 76.178673"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25)"
+   sodipodi:docname="terminal_logo_dark.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="true"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     inkscape:zoom="0.92737795"
+     inkscape:cx="248.01107"
+     inkscape:cy="186.54746"
+     inkscape:window-width="1392"
+     inkscape:window-height="1051"
+     inkscape:window-x="2412"
+     inkscape:window-y="73"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-39.512966,-99.426514)">
+    <text
+       xml:space="preserve"
+       style="font-size:25.4px;font-family:Helvetica;-inkscape-font-specification:Helvetica;text-align:center;text-anchor:middle;opacity:0.579505;fill:#ffffff;fill-opacity:0.99999964;stroke:#000000;stroke-width:0;stroke-opacity:1"
+       x="93.293953"
+       y="129.52736"
+       id="text1"><tspan
+         sodipodi:role="line"
+         id="tspan1"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:25.4px;font-family:Helvetica;-inkscape-font-specification:'Helvetica Bold';fill:#ffffff;fill-opacity:0.99999964;stroke-width:0;stroke:#000000;stroke-opacity:1"
+         x="93.293953"
+         y="129.52736">Dummy</tspan><tspan
+         sodipodi:role="line"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:25.4px;font-family:Helvetica;-inkscape-font-specification:'Helvetica Bold';fill:#ffffff;fill-opacity:0.99999964;stroke-width:0;stroke:#000000;stroke-opacity:1"
+         x="93.293953"
+         y="161.27736"
+         id="tspan2">Logo</tspan></text>
+    <rect
+       style="opacity:0.579505;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-dasharray:none;stroke-opacity:1"
+       id="rect2"
+       width="107.84438"
+       height="74.178673"
+       x="40.512966"
+       y="100.42651"
+       ry="13.123919" />
+  </g>
+</svg>

--- a/docs/_static/terminal_logo_light.svg
+++ b/docs/_static/terminal_logo_light.svg
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="109.84438mm"
+   height="76.178673mm"
+   viewBox="0 0 109.84438 76.178673"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25)"
+   sodipodi:docname="terminal_logo_light.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     inkscape:zoom="0.92737795"
+     inkscape:cx="248.01107"
+     inkscape:cy="186.54746"
+     inkscape:window-width="1392"
+     inkscape:window-height="1051"
+     inkscape:window-x="2410"
+     inkscape:window-y="129"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-39.512966,-99.426514)">
+    <text
+       xml:space="preserve"
+       style="font-size:25.4px;font-family:Helvetica;-inkscape-font-specification:Helvetica;text-align:center;text-anchor:middle;opacity:0.579505;fill:#ff1d18;fill-opacity:0.625498;stroke:#000000;stroke-width:0;stroke-opacity:1"
+       x="93.293953"
+       y="129.52736"
+       id="text1"><tspan
+         sodipodi:role="line"
+         id="tspan1"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:25.4px;font-family:Helvetica;-inkscape-font-specification:'Helvetica Bold';fill:#000000;fill-opacity:1;stroke-width:0;stroke:#000000;stroke-opacity:1"
+         x="93.293953"
+         y="129.52736">Dummy</tspan><tspan
+         sodipodi:role="line"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:25.4px;font-family:Helvetica;-inkscape-font-specification:'Helvetica Bold';fill:#000000;fill-opacity:1;stroke-width:0;stroke:#000000;stroke-opacity:1"
+         x="93.293953"
+         y="161.27736"
+         id="tspan2">Logo</tspan></text>
+    <rect
+       style="opacity:0.579505;fill:none;fill-opacity:1;stroke:#000000;stroke-width:2;stroke-dasharray:none;stroke-opacity:1"
+       id="rect2"
+       width="107.84438"
+       height="74.178673"
+       x="40.512966"
+       y="100.42651"
+       ry="13.123919" />
+  </g>
+</svg>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,1 @@
+../CHANGELOG.md

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,25 @@
+from datetime import date
+import json
+from pathlib import Path
+
+PACKAGE_JSON_FILENAME = Path(__file__).parent.parent / "package.json"
+PACKAGE_JSON = json.loads(PACKAGE_JSON_FILENAME.read_text(encoding="utf-8"))
+
+project = 'JupyterLite Terminal'
+author = PACKAGE_JSON["author"]["name"]
+copyright = f"2024-{date.today().year}, {author}"
+release = PACKAGE_JSON["version"]
+
+extensions = [
+    "myst_parser"
+]
+
+templates_path = ['_templates']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+html_static_path = ['_static']
+html_theme = "pydata_sphinx_theme"
+html_theme_options = {
+    "github_url": PACKAGE_JSON["homepage"],
+}
+html_title = "JupyterLite Terminal"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,6 +11,7 @@ copyright = f"2024-{date.today().year}, {author}"
 release = PACKAGE_JSON["version"]
 
 extensions = [
+    "jupyterlite_sphinx",
     "myst_parser"
 ]
 
@@ -29,3 +30,8 @@ html_theme_options = {
    }
 }
 html_title = "JupyterLite Terminal"
+
+# jupyterlite_sphonx settings
+jupyterlite_contents = "../deploy/contents/"
+jupyterlite_dir = "../deploy/"
+jupyterlite_silence = False

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,5 +21,11 @@ html_static_path = ['_static']
 html_theme = "pydata_sphinx_theme"
 html_theme_options = {
     "github_url": PACKAGE_JSON["homepage"],
+    "logo": {
+        "alt_text": "JupyterLite Terminal - Home",
+        "image_dark": "_static/terminal_logo_dark.svg",
+        "image_light": "_static/terminal_logo_light.svg",
+        "text": "JupyterLite Terminal",
+   }
 }
 html_title = "JupyterLite Terminal"

--- a/docs/environment-docs.yml
+++ b/docs/environment-docs.yml
@@ -1,0 +1,17 @@
+name: terminal-docs
+channels:
+  - conda-forge
+dependencies:
+  # General build dependencies
+  - micromamba
+  - nodejs =20
+  - python =3.13
+
+  # Jupyter dependencies
+  - jupyterlite-core >=0.6,<0.8.0
+
+  # Docs dependencies
+  - jupyterlite-sphinx
+  - myst-parser
+  - pydata-sphinx-theme
+  - sphinx

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,11 @@
+# JupyterLite Terminal
+
+Blah blah blah.
+
+## Contents
+
+```{toctree}
+:maxdepth: 1
+
+changelog
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,4 +10,4 @@ Blah blah blah.
 changelog
 ```
 
-Link to <a href="lite">deployment</a>.
+Link to <a href="./lite">deployment</a>.

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,3 +9,5 @@ Blah blah blah.
 
 changelog
 ```
+
+Link to <a href="lite">deployment</a>.

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,0 +1,3 @@
+myst-parser
+pydata-sphinx-theme
+sphinx

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,3 +1,4 @@
+jupyterlite-sphinx
 myst-parser
 pydata-sphinx-theme
 sphinx

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,4 +1,0 @@
-jupyterlite-sphinx
-myst-parser
-pydata-sphinx-theme
-sphinx


### PR DESCRIPTION
Add infrastructure for project docs using sphinx and myst.

To build docs:
```bash
cd docs
pip install -r requirements-docs.txt
make html
```

and the output is in the `_build/html` directory.

Currently doesn't build the `terminal` beforehand, but this may have to change if for example we need to extract API docs. 

No content yet, and not yet building in CI.