### PR TITLE
Support use of `lite_dir` when deploying

### DIFF
--- a/jupyterlite_terminal/add_on.py
+++ b/jupyterlite_terminal/add_on.py
@@ -20,22 +20,25 @@ class TerminalAddon(FederatedExtensionAddon):
         super().__init__(*args, **kwargs)
 
     def post_build(self, manager):
+        lite_dir = manager.lite_dir
+        output_dir = manager.output_dir
+
         cockleTool = Path("node_modules", "@jupyterlite", "cockle", "lib", "tools", "prepare_wasm.js")
         if not cockleTool.is_file():
             cockleTool = ".cockle_temp" / cockleTool
             cmd = ["npm", "install", "--no-save", "--prefix", cockleTool.parts[0], "@jupyterlite/cockle"]
             print("TerminalAddon:", " ".join(cmd))
-            subprocess.run(cmd, check=True)
+            subprocess.run(cmd, check=True, cwd=lite_dir)
 
-        assetDir = Path(self.manager.output_dir) / "extensions" / "@jupyterlite" / "terminal" / "static" / "wasm"
+        assetDir = output_dir / "extensions" / "@jupyterlite" / "terminal" / "static" / "wasm"
 
         # Although cockle's prepare_wasm is perfectly capable of copying the wasm and associated
         # files to the asset directory, here we just get the list of required files and let the
         # add-on do the copying for consistency with other extensions.
-        tempFilename = 'cockle-files.txt'
-        cmd = ["node", str(cockleTool), "--list", tempFilename]
+        tempFilename = lite_dir / 'cockle-files.txt'
+        cmd = ["node", str(cockleTool), "--list", str(tempFilename)]
         print("TerminalAddon:", " ".join(cmd))
-        subprocess.run(cmd, check=True)
+        subprocess.run(cmd, check=True, cwd=lite_dir)
 
         with open(tempFilename, 'r') as f:
             for source in f:
@@ -44,7 +47,7 @@ class TerminalAddon(FederatedExtensionAddon):
                 packageName = next(f).strip()
                 yield dict(
                     name=f"copy:{basename}",
-                    actions=[(self.copy_one, [source, assetDir / packageName / basename])],
+                    actions=[(self.copy_one, [lite_dir / source, assetDir / packageName / basename])],
                 )
 
         os.remove(tempFilename)


### PR DESCRIPTION
Previously the add on code used at deployment time has assumed that the `cwd` is the root deployment directory. This PR supports the use of `--lite-dir` to specify a different directory.

For example, to build the demo deployment from the root repo dir rather than the `deploy` directory, with this PR the following works:
```bash
jupyter lite build --lite-dir=deploy
npx static-handler deploy/_output/
```