### PR TITLE
Add github action containing link to Read the Docs PR preview

### DIFF
--- a/.github/workflows/rtd-preview.yml
+++ b/.github/workflows/rtd-preview.yml
@@ -1,0 +1,24 @@
+name: Read the Docs preview
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  binder:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment on the PR with the RTD preview
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            var PR_NUMBER = context.issue.number
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `[View PR preview of docs and deployment on Read the Docs](https://jupyterlite-terminal--${PR_NUMBER}.org.readthedocs.build/en/${PR_NUMBER})`
+            })


### PR DESCRIPTION
Add github action containing link to Read the Docs PR preview of the docs and deployment. Based on similar in the JupyterLite repo.