### PR TITLE
Pass on themeChanged boolean to cockle

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -156,10 +156,7 @@ export class LiteTerminalAPIClient implements ILiteTerminalAPIClient {
 
   themeChange(isDarkMode?: boolean): void {
     for (const shell of this._shells.values()) {
-      // Can pass isDarkMode when cockle is released with PR #232.
-      //shell.themeChange(isDarkMode);
-
-      shell.themeChange();
+      shell.themeChange(isDarkMode);
     }
   }
 


### PR DESCRIPTION
Follow up to #62 to pass on optional `isDarkMode` boolean to cockle's `themeChanged`. Support for this was added in jupyterlite/cockle#232 and released in cockle 1.0.0.

It can be confirmed that this is working in the browser's console. A terminal theme change to something other than `inherit` does not have this boolean so cockle has to check if the terminal background color is dark and it reports this in the console via:
```
Cockle theme change 5 ms
```

When the terminal theme is `inherit` and the JupyterLite theme is changed to one of the default themes such as `JupyterLab Dark` or `JupyterLab Light` then it knows if it is dark mode and hence no such line is written to the console.