### PR TITLE
Add git2cpp to deployment

### DIFF
--- a/deploy/cockle-config-in.json
+++ b/deploy/cockle-config-in.json
@@ -1,11 +1,20 @@
 {
   "packages": {
+    "git2cpp": {},
     "lua": {},
     "nano": {},
     "tree": {},
     "vim": {}
   },
   "aliases": {
+    "git": "git2cpp",
     "vi": "vim"
+  },
+  "environment": {
+    "GIT_CORS_PROXY": "https://corsproxy.io/?url=",
+    "GIT_AUTHOR_NAME": "Jane Doe",
+    "GIT_AUTHOR_EMAIL": "jane.doe@blabla.com",
+    "GIT_COMMITTER_NAME": "Jane Doe",
+    "GIT_COMMITTER_EMAIL": "jane.doe@blabla.com"
   }
 }


### PR DESCRIPTION
Add `git2cpp` to deployment, to check it works.

Here is a screenshot of it working locally using `git clone`, `git add`, `git commit` and `git log`:

<img width="923" height="722" alt="Screenshot 2025-10-13 at 13 29 24" src="https://github.com/user-attachments/assets/8efa2ab1-48ae-4759-9e6c-e04d78c20794" />

This needs `jupyterlite 0.7.0a7` as it needs the fix in jupyterlite/jupyterlite#1742. Do not merge this until `jupyterlite 0.7.0` is released and we can remove the alpha version pins here.