### PR TITLE
Enforce type imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,6 +159,13 @@
             "@typescript-eslint"
         ],
         "rules": {
+            "@typescript-eslint/consistent-type-imports": [
+                "error",
+                {
+                    "prefer": "type-imports",
+                    "fixStyle": "separate-type-imports"
+                }
+            ],
             "@typescript-eslint/naming-convention": [
                 "error",
                 {

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,22 +1,22 @@
 import { PageConfig, URLExt } from '@jupyterlab/coreutils';
-import { ServerConnection, Terminal } from '@jupyterlab/services';
-import {
+import type { Terminal } from '@jupyterlab/services';
+import { ServerConnection } from '@jupyterlab/services';
+import type {
   IExternalCommand,
   IShellManager,
   IStdinReply,
-  IStdinRequest,
-  ShellManager
+  IStdinRequest
 } from '@jupyterlite/cockle';
-import { JSONPrimitive } from '@lumino/coreutils';
-import { ISignal, Signal } from '@lumino/signaling';
+import { ShellManager } from '@jupyterlite/cockle';
+import type { JSONPrimitive } from '@lumino/coreutils';
+import type { ISignal } from '@lumino/signaling';
+import { Signal } from '@lumino/signaling';
 
-import {
-  Server as WebSocketServer,
-  Client as WebSocketClient
-} from 'mock-socket';
+import type { Client as WebSocketClient } from 'mock-socket';
+import { Server as WebSocketServer } from 'mock-socket';
 
 import { Shell } from './shell';
-import { ILiteTerminalAPIClient } from './tokens';
+import type { ILiteTerminalAPIClient } from './tokens';
 
 export class LiteTerminalAPIClient implements ILiteTerminalAPIClient {
   constructor(options: { serverSettings?: ServerConnection.ISettings } = {}) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,16 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import {
+import type {
   JupyterFrontEnd,
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
 import { IThemeManager } from '@jupyterlab/apputils';
+import type { ServiceManagerPlugin, Terminal } from '@jupyterlab/services';
 import {
   IServerSettings,
   ITerminalManager,
   ServerConnection,
-  ServiceManagerPlugin,
-  Terminal,
   TerminalManager
 } from '@jupyterlab/services';
 import { IServiceWorkerManager } from '@jupyterlite/apputils';

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -1,6 +1,7 @@
-import { BaseShell, IShell } from '@jupyterlite/cockle';
+import type { IShell } from '@jupyterlite/cockle';
+import { BaseShell } from '@jupyterlite/cockle';
 
-import { Client as WebSocketClient } from 'mock-socket';
+import type { Client as WebSocketClient } from 'mock-socket';
 
 /**
  * Shell class that uses web worker that plugs into a DriveFS via the service worker.

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -1,11 +1,11 @@
-import { Terminal } from '@jupyterlab/services';
-import {
+import type { Terminal } from '@jupyterlab/services';
+import type {
   IExternalCommand,
   IStdinReply,
   IStdinRequest
 } from '@jupyterlite/cockle';
 import { Token } from '@lumino/coreutils';
-import { ISignal } from '@lumino/signaling';
+import type { ISignal } from '@lumino/signaling';
 
 export const ILiteTerminalAPIClient = new Token<ILiteTerminalAPIClient>(
   '@jupyterlite/terminal:client'

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,6 +1,7 @@
 import { expose } from 'comlink';
 
-import { BaseShellWorker, IDriveFSOptions } from '@jupyterlite/cockle';
+import type { IDriveFSOptions } from '@jupyterlite/cockle';
+import { BaseShellWorker } from '@jupyterlite/cockle';
 import { DriveFS } from '@jupyterlite/services';
 
 /**


### PR DESCRIPTION
Add linter rule to enforce import of types only where possible as in jupyterlite/jupyterlite#1786. Should result in smaller shipped web worker size.