### PR TITLE
Add python 3.14, remove 3.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,11 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.14'
+
     - name: Base Setup
       uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
@@ -77,11 +82,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Install Python
+    - name: Setup Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
-        architecture: 'x64'
+        python-version: '3.14'
 
     - uses: actions/download-artifact@v4
       with:
@@ -100,7 +104,7 @@ jobs:
         jupyter labextension list 2>&1 | grep -ie "@jupyterlite/terminal.*OK"
 
   integration-tests:
-    name: Integration tests ${{ matrix.lite-version}}
+    name: Integration tests ${{ matrix.python-version}} ${{ matrix.lite-version}}
     needs: build
     runs-on: ubuntu-latest
 
@@ -108,6 +112,7 @@ jobs:
       fail-fast: false
       matrix:
         lite-version: ['min', 'normal', 'max']
+        python-version: ['3.10', '3.14']
 
     env:
       PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/pw-browsers
@@ -115,6 +120,11 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+
+    - name: Setup Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
 
     - name: Base Setup
       uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.14'
 
       - name: Install the dependencies
         run: |

--- a/.github/workflows/update-integration-tests.yml
+++ b/.github/workflows/update-integration-tests.yml
@@ -25,6 +25,11 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.14'
+
       - name: Checkout the branch from the PR that triggered the job
         run: gh pr checkout ${{ github.event.issue.number }}
         env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "jupyterlite_terminal"
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     "Framework :: Jupyter",
     "Framework :: Jupyter :: JupyterLab",
@@ -16,11 +16,11 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
     # Changes here should be synchronised with .github/workflows/build.yml


### PR DESCRIPTION
Adding classifiers for python 3.14, removing them for 3.9 as it has reached end of life. Explicitly testing on the lower and upper python limits in CI.