### PR TITLE
Update to jupyterlite 0.7.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ concurrency:
 env:
   # Min and max limits of jupyterlite-core versions that this should work on.
   # Changes here should be synchronised with pyproject.toml dependencies section.
-  MIN_LITE_VERSION: jupyterlite-core==0.7.0rc0
+  MIN_LITE_VERSION: jupyterlite-core==0.7.0
   MAX_LITE_VERSION: --pre jupyterlite-core<0.8.0
 
   LAB_VERSION: jupyterlab>=4.0.0,<5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Install the dependencies
         run: |
-          python -m pip install "jupyterlite-core>=0.6,<0.7" jupyterlite-pyodide-kernel
+          python -m pip install jupyterlite-pyodide-kernel
 
           # install a dev version of the terminal extension
           python -m pip install .

--- a/.github/workflows/update-integration-tests.yml
+++ b/.github/workflows/update-integration-tests.yml
@@ -39,7 +39,7 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
       - name: Install dependencies
-        run: python -m pip install -U "jupyterlite-core>=0.6,<0.7" "jupyterlab>=4,<5"
+        run: python -m pip install -U "jupyterlab>=4,<5"
 
       - name: Install extension
         run: |

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A terminal for JupyterLite.
 
 ## Requirements
 
-- JupyterLite >= 0.6.0, < 0.8.0
+- JupyterLite >= 0.7.0, < 0.8.0
 
 ## Install
 

--- a/docs/environment-docs.yml
+++ b/docs/environment-docs.yml
@@ -8,7 +8,7 @@ dependencies:
   - python =3.13
 
   # Jupyter dependencies
-  - jupyterlite-core >=0.6,<0.8.0
+  - jupyterlite-core >=0.7,<0.8.0
 
   # Docs dependencies
   - jupyterlite-sphinx

--- a/package.json
+++ b/package.json
@@ -64,9 +64,9 @@
         "@jupyterlab/pluginmanager": "^4.5.0",
         "@jupyterlab/services": "^7.5.0",
         "@jupyterlab/settingregistry": "^4.5.0",
-        "@jupyterlite/apputils": "^0.7.0-rc.0",
+        "@jupyterlite/apputils": "^0.7.0",
         "@jupyterlite/cockle": "^1.3.0",
-        "@jupyterlite/services": "^0.7.0-rc.0",
+        "@jupyterlite/services": "^0.7.0",
         "@lumino/coreutils": "^2.2.1",
         "@lumino/signaling": "^2.1.4",
         "mock-socket": "^9.3.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 dependencies = [
     # Changes here should be synchronised with .github/workflows/build.yml
-    "jupyterlite-core>=0.7.0rc0,<0.8.0"
+    "jupyterlite-core>=0.7.0,<0.8.0"
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2592,7 +2592,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/pluginmanager@npm:^4.5.0":
+"@jupyterlab/pluginmanager@npm:^4.5.0, @jupyterlab/pluginmanager@npm:~4.5.0":
   version: 4.5.0
   resolution: "@jupyterlab/pluginmanager@npm:4.5.0"
   dependencies:
@@ -2810,9 +2810,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlite/application@npm:^0.7.0-rc.0":
-  version: 0.7.0-rc.0
-  resolution: "@jupyterlite/application@npm:0.7.0-rc.0"
+"@jupyterlite/application@npm:^0.7.0":
+  version: 0.7.0
+  resolution: "@jupyterlite/application@npm:0.7.0"
   dependencies:
     "@jupyterlab/application": ~4.5.0
     "@jupyterlab/coreutils": ~6.5.0
@@ -2821,32 +2821,33 @@ __metadata:
     "@lumino/coreutils": ^2.2.2
     "@lumino/signaling": ^2.1.5
     "@lumino/widgets": ^2.7.2
-  checksum: 77b11b21d384b8c5b9f95fee52effa1835046f9e033fd022845447f9418bb7148b5bd8ae8b18889cdca049c379efb89cdb78c5e09ee8dbc3f3141bfed8c230d5
+  checksum: ea743bf6a81ff0b92a61aca0f88cbf31a192a14daf7544cceb936c6e811e4aaac9db65e9a69f017cdaf0c879f5c927fd3aef280c99339b4b68da74c49607938e
   languageName: node
   linkType: hard
 
-"@jupyterlite/apputils@npm:^0.7.0-rc.0":
-  version: 0.7.0-rc.0
-  resolution: "@jupyterlite/apputils@npm:0.7.0-rc.0"
+"@jupyterlite/apputils@npm:^0.7.0":
+  version: 0.7.0
+  resolution: "@jupyterlite/apputils@npm:0.7.0"
   dependencies:
     "@jupyterlab/application": ~4.5.0
     "@jupyterlab/apputils": ~4.6.0
     "@jupyterlab/coreutils": ~6.5.0
     "@jupyterlab/nbformat": ~4.5.0
     "@jupyterlab/observables": ~5.5.0
+    "@jupyterlab/pluginmanager": ~4.5.0
     "@jupyterlab/services": ~7.5.0
     "@jupyterlab/settingregistry": ~4.5.0
     "@jupyterlab/statedb": ~4.5.0
     "@jupyterlab/translation": ~4.5.0
-    "@jupyterlite/application": ^0.7.0-rc.0
-    "@jupyterlite/services": ^0.7.0-rc.0
-    "@jupyterlite/types": ^0.7.0-rc.0
+    "@jupyterlite/application": ^0.7.0
+    "@jupyterlite/services": ^0.7.0
+    "@jupyterlite/types": ^0.7.0
     "@lumino/application": ^2.4.5
     "@lumino/coreutils": ^2.2.2
     "@lumino/signaling": ^2.1.5
     "@types/emscripten": ^1.39.6
     mock-socket: ^9.3.1
-  checksum: f08421e14c57024f9d64106b374661da336ca0b7bf81ea4f9df814c1ed062af95a55d86982e0074e0df90f48b28422f3400487f40897ee69481e2c63e352a561
+  checksum: 87c249d55b73456645d86d909f974a7a11fd091312f174b32fba3aa065c53649195fb0242167d02e45b7c3d51412fa3a16bf3b8b760649b1139edcc3ee6c95b8
   languageName: node
   linkType: hard
 
@@ -2865,28 +2866,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlite/localforage@npm:^0.7.0-rc.0":
-  version: 0.7.0-rc.0
-  resolution: "@jupyterlite/localforage@npm:0.7.0-rc.0"
+"@jupyterlite/localforage@npm:^0.7.0":
+  version: 0.7.0
+  resolution: "@jupyterlite/localforage@npm:0.7.0"
   dependencies:
     "@jupyterlab/coreutils": ~6.5.0
     "@lumino/coreutils": ^2.2.2
     localforage: ^1.9.0
     localforage-memoryStorageDriver: ^0.9.2
-  checksum: 4455a53864728df6d00f81b36727329f8adcf3ff57bb436b793725a3bb33dc6eccb1d5f5d8e1fee41a6b650c36029fdeeffeb351056939ba5cc813a12b3ff1c0
+  checksum: bf206fb2d043a35f56f5400473080e04896f30c193dcb0688b9c5277dad933f352746bbb3197e6f760a56d5f674d03000ddd4fb6e64679269621d6e1a77a8ac2
   languageName: node
   linkType: hard
 
-"@jupyterlite/services@npm:^0.7.0-rc.0":
-  version: 0.7.0-rc.0
-  resolution: "@jupyterlite/services@npm:0.7.0-rc.0"
+"@jupyterlite/services@npm:^0.7.0":
+  version: 0.7.0
+  resolution: "@jupyterlite/services@npm:0.7.0"
   dependencies:
     "@jupyterlab/coreutils": ~6.5.0
     "@jupyterlab/nbformat": ~4.5.0
     "@jupyterlab/observables": ~5.5.0
     "@jupyterlab/services": ~7.5.0
     "@jupyterlab/settingregistry": ~4.5.0
-    "@jupyterlite/localforage": ^0.7.0-rc.0
+    "@jupyterlite/localforage": ^0.7.0
     "@lumino/algorithm": ^2.0.4
     "@lumino/coreutils": ^2.2.2
     "@lumino/disposable": ^2.1.5
@@ -2898,7 +2899,7 @@ __metadata:
     localforage: ^1.9.0
     mime: ^3.0.0
     mock-socket: ^9.3.1
-  checksum: bef35b92594089f4f4bb3372285753b1a7b15a3a8df08f50e02ed55bacb13276ec32371b3d0e52d0f6857d07307116b1de6cc8bafe13aeb5a3819981a5ecae9a
+  checksum: d677e95e0941e9161bbfe55674795d8e6ad25df7f711a846d31242a629b6d7d845711a47f65864dcc738d119c345cd60cf83f803021c181fd622bdf376d27100
   languageName: node
   linkType: hard
 
@@ -2913,9 +2914,9 @@ __metadata:
     "@jupyterlab/services": ^7.5.0
     "@jupyterlab/settingregistry": ^4.5.0
     "@jupyterlab/testutils": ^4.5.0
-    "@jupyterlite/apputils": ^0.7.0-rc.0
+    "@jupyterlite/apputils": ^0.7.0
     "@jupyterlite/cockle": ^1.3.0
-    "@jupyterlite/services": ^0.7.0-rc.0
+    "@jupyterlite/services": ^0.7.0
     "@lumino/coreutils": ^2.2.1
     "@lumino/signaling": ^2.1.4
     "@types/jest": ^29.2.0
@@ -2948,12 +2949,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@jupyterlite/types@npm:^0.7.0-rc.0":
-  version: 0.7.0-rc.0
-  resolution: "@jupyterlite/types@npm:0.7.0-rc.0"
+"@jupyterlite/types@npm:^0.7.0":
+  version: 0.7.0
+  resolution: "@jupyterlite/types@npm:0.7.0"
   dependencies:
     "@lumino/coreutils": ^2.2.2
-  checksum: 81aa263319ac9bc7c89125e83dcf88729a211a0dec0083722f2884d54944a5db9e8d4307fa9bdc1bb04813f5f2a2bf07be7d5dc00d6437e3dbbabfb019f48a01
+  checksum: 9375d47829206e39fd78c0fba9f63fa55c42cc12d6aa9632fe65afcc56ac19bee0f7b0512db29e107e0f52ac18d6dc79275d9eee3843737ed6d1c9f753fed10d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Update to `jupyterlite 0.7.0`. This is now the minimum runtime requirement due to the use of the new [@jupyterlite/services](https://jupyterlite.readthedocs.io/en/stable/migration.html#package-consolidation) package which is not available in `jupyterlite < 0.7`.