### PR TITLE
Add JupyterLab commands for programmatic use

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,22 +47,22 @@ jupyter lite build
 ## Running commands programmatically
 
 Besides the interactive terminal, the extension registers JupyterLab commands that
-run bash in a _headless_ `cockle` shell: one that captures the output and exit code
-without opening a terminal widget. These are useful for other extensions or
+run commands in a _headless_ `cockle` shell: one that captures the output and exit
+code without opening a terminal widget. These are useful for other extensions or
 automation that need to run shell commands in JupyterLite.
 
-| Command                                   | Description                                            |
-| ----------------------------------------- | ------------------------------------------------------ |
-| `@jupyterlite/terminal:execute-bash`      | Run a bash command and return its output and exit code |
-| `@jupyterlite/terminal:start-terminal`    | Start a reusable headless shell                        |
-| `@jupyterlite/terminal:shutdown-terminal` | Shut down a headless shell by name                     |
-| `@jupyterlite/terminal:list-terminals`    | List the running headless shells                       |
+| Command                                | Description                                       |
+| -------------------------------------- | ------------------------------------------------- |
+| `@jupyterlite/terminal:execute-shell`  | Run a command and return its output and exit code |
+| `@jupyterlite/terminal:start-shell`    | Start a reusable headless shell                   |
+| `@jupyterlite/terminal:shutdown-shell` | Shut down a headless shell by name                |
+| `@jupyterlite/terminal:list-shells`    | List the running headless shells                  |
 
 Run a single command (a throwaway shell is created and disposed automatically):
 
 ```ts
 const result = await app.commands.execute(
-  '@jupyterlite/terminal:execute-bash',
+  '@jupyterlite/terminal:execute-shell',
   {
     code: 'echo hello'
   }
@@ -71,22 +71,22 @@ console.log(result.exitCode); // 0
 console.log(result.output); // hello
 ```
 
-Pass a `terminalName` to reuse a shell across calls so state such as the working
+Pass a `shellName` to reuse a shell across calls so state such as the working
 directory persists:
 
 ```ts
-const { terminalName } = await app.commands.execute(
-  '@jupyterlite/terminal:start-terminal'
+const { shellName } = await app.commands.execute(
+  '@jupyterlite/terminal:start-shell'
 );
-await app.commands.execute('@jupyterlite/terminal:execute-bash', {
+await app.commands.execute('@jupyterlite/terminal:execute-shell', {
   code: 'cd /drive',
-  terminalName
+  shellName
 });
 const result = await app.commands.execute(
-  '@jupyterlite/terminal:execute-bash',
+  '@jupyterlite/terminal:execute-shell',
   {
     code: 'pwd',
-    terminalName
+    shellName
   }
 );
 console.log(result.output); // /drive

--- a/README.md
+++ b/README.md
@@ -44,6 +44,58 @@ Then build a new JupyterLite site:
 jupyter lite build
 ```
 
+## Running commands programmatically
+
+Besides the interactive terminal, the extension registers JupyterLab commands that
+run bash in a _headless_ `cockle` shell: one that captures the output and exit code
+without opening a terminal widget. These are useful for other extensions or
+automation that need to run shell commands in JupyterLite.
+
+| Command                                   | Description                                            |
+| ----------------------------------------- | ------------------------------------------------------ |
+| `@jupyterlite/terminal:execute-bash`      | Run a bash command and return its output and exit code |
+| `@jupyterlite/terminal:start-terminal`    | Start a reusable headless shell                        |
+| `@jupyterlite/terminal:shutdown-terminal` | Shut down a headless shell by name                     |
+| `@jupyterlite/terminal:list-terminals`    | List the running headless shells                       |
+
+Run a single command (a throwaway shell is created and disposed automatically):
+
+```ts
+const result = await app.commands.execute(
+  '@jupyterlite/terminal:execute-bash',
+  {
+    code: 'echo hello'
+  }
+);
+console.log(result.exitCode); // 0
+console.log(result.output); // hello
+```
+
+Pass a `terminalName` to reuse a shell across calls so state such as the working
+directory persists:
+
+```ts
+const { terminalName } = await app.commands.execute(
+  '@jupyterlite/terminal:start-terminal'
+);
+await app.commands.execute('@jupyterlite/terminal:execute-bash', {
+  code: 'cd /drive',
+  terminalName
+});
+const result = await app.commands.execute(
+  '@jupyterlite/terminal:execute-bash',
+  {
+    code: 'pwd',
+    terminalName
+  }
+);
+console.log(result.output); // /drive
+```
+
+Each command runs as a single `cockle` pipeline, so `|`, `;` and redirections
+(`>`, `>>`, `2>`, `<`) work, but `&&`/`||`, command substitution and `$VAR`
+expansion are not supported.
+
 ## Version compatibility
 
 Each `jupyterlite-terminal` release is built against a specific version of `cockle`. If you need to

--- a/src/client.ts
+++ b/src/client.ts
@@ -22,8 +22,8 @@ import type { ILiteTerminalAPIClient } from './tokens';
 
 /**
  * Default time (in milliseconds) to wait for a new shell to become ready.
- * Cockle disposes the shell without rejecting `ready` if it fails to
- * initialize, so race the wait against this timeout to surface the failure.
+ * A shell that fails to start is disposed without its `ready` promise
+ * rejecting, so race the wait against this timeout to surface the failure.
  */
 const DEFAULT_READY_TIMEOUT_MS = 30000;
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -3,6 +3,8 @@ import type { Terminal } from '@jupyterlab/services';
 import { ServerConnection } from '@jupyterlab/services';
 import type {
   IExternalCommand,
+  IOutputCallback,
+  IShell,
   IShellManager,
   IStdinReply,
   IStdinRequest
@@ -17,6 +19,13 @@ import { Server as WebSocketServer } from 'mock-socket';
 
 import { Shell } from './shell';
 import type { ILiteTerminalAPIClient } from './tokens';
+
+/**
+ * Default time (in milliseconds) to wait for a new shell to become ready.
+ * Cockle disposes the shell without rejecting `ready` if it fails to
+ * initialize, so race the wait against this timeout to surface the failure.
+ */
+const DEFAULT_READY_TIMEOUT_MS = 30000;
 
 export class LiteTerminalAPIClient implements ILiteTerminalAPIClient {
   constructor(options: { serverSettings?: ServerConnection.ISettings } = {}) {
@@ -139,6 +148,67 @@ export class LiteTerminalAPIClient implements ILiteTerminalAPIClient {
 
   registerExternalCommand(options: IExternalCommand.IOptions): void {
     this._externalCommands.push(options);
+  }
+
+  async createHeadlessShell(options: {
+    shellId: string;
+    cwd?: string;
+    environment?: { [key: string]: string | undefined };
+    outputCallback: IOutputCallback;
+    readyTimeoutMs?: number;
+  }): Promise<IShell> {
+    const { baseUrl } = this.serverSettings;
+    const environment =
+      options.environment !== undefined
+        ? { ...this._environment, ...options.environment }
+        : this._environment;
+    // `color: true` keeps TERM/TERMINFO populated for commands that need them.
+    const shell = new Shell({
+      shellId: options.shellId,
+      mountpoint: '/drive',
+      cwd: options.cwd,
+      baseUrl,
+      wasmBaseUrl: URLExt.join(
+        baseUrl,
+        'extensions/@jupyterlite/terminal/static/wasm/'
+      ),
+      browsingContextId: this._browsingContextId,
+      shellManager: this._shellManager,
+      aliases: this._aliases,
+      environment,
+      externalCommands: this._externalCommands,
+      color: true,
+      outputCallback: options.outputCallback
+    });
+
+    const readyTimeoutMs = options.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS;
+    let readyTimer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await Promise.race([
+        shell.ready,
+        new Promise<never>((_, reject) => {
+          readyTimer = setTimeout(
+            () =>
+              reject(
+                new Error(
+                  `Timed out after ${readyTimeoutMs}ms waiting for cockle shell '${options.shellId}' to become ready`
+                )
+              ),
+            readyTimeoutMs
+          );
+        })
+      ]);
+      await shell.start();
+    } catch (err) {
+      shell.dispose();
+      throw err;
+    } finally {
+      if (readyTimer !== undefined) {
+        clearTimeout(readyTimer);
+      }
+    }
+
+    return shell;
   }
 
   async shutdown(name: string): Promise<void> {

--- a/src/exec.ts
+++ b/src/exec.ts
@@ -385,7 +385,7 @@ function registerCommands(
  */
 export const terminalExecPlugin: JupyterFrontEndPlugin<void> = {
   id: '@jupyterlite/terminal:exec',
-  description: 'AI-friendly headless shell exec commands backed by cockle',
+  description: 'Headless shell exec commands backed by cockle',
   autoStart: true,
   requires: [ILiteTerminalAPIClient],
   activate: (

--- a/src/exec.ts
+++ b/src/exec.ts
@@ -110,9 +110,9 @@ class HeadlessShellPool {
 }
 
 /**
- * Normalize the captured TTY buffer for callers that expect pipe-like output.
- * Cockle translates `\n` to `\r\n` on TTY writes (ONLCR) and echoes the input
- * line back, so undo both: convert `\r\n` to `\n` and strip the leading echo.
+ * Normalize the raw shell output for callers that expect pipe-like text. The
+ * captured buffer echoes back the submitted command and uses `\r\n` line
+ * endings, so strip the echoed command line and convert `\r\n` to `\n`.
  */
 function cleanCapturedOutput(captured: string, code: string): string {
   const normalized = captured.replace(/\r\n/g, '\n');
@@ -129,8 +129,8 @@ async function runOnSession(
   timeout: number
 ): Promise<IExecuteBashResult> {
   const shellId = session.shell.shellId;
-  // Cockle runs the command on `\r`, so fold any CR/CRLF inside the command
-  // into `\n` to avoid executing a multi-line command one line too early.
+  // Fold any CR/CRLF inside the command to `\n` so it runs as a single command
+  // rather than one line at a time when submitted with a trailing `\r`.
   const command = code.trim().replace(/\r\n?/g, '\n');
   if (command.length === 0) {
     return {
@@ -144,9 +144,9 @@ async function runOnSession(
     };
   }
 
-  // A timed-out command keeps running in the worker, leaving the session in an
-  // unknown state, so refuse to reuse it. Also refuse overlapping commands,
-  // whose input and captured output would otherwise interleave.
+  // A timed-out command keeps running, so the session is left in an unknown
+  // state; refuse to reuse it. Also refuse overlapping commands, whose input
+  // and captured output would otherwise interleave.
   if (session.timedOut) {
     throw new Error(
       `Headless shell '${shellId}' is no longer usable after a command timed out`
@@ -159,9 +159,9 @@ async function runOnSession(
 
   const startTime = Date.now();
   const startLen = session.output.length;
-  // `input()` resolves once the worker has run the command, so it doubles as
-  // the "command finished" signal. Cockle has no interrupt, so race it against
-  // a timer to avoid hanging on a command that blocks (e.g. on stdin).
+  // `input()` resolves only after the command has finished, so it doubles as
+  // the "command finished" signal. A running command cannot be interrupted, so
+  // race it against a timer to avoid hanging on one that blocks (e.g. on stdin).
   const inputDone = session.shell.input(command + '\r').then(
     () => false,
     () => false // a late rejection (e.g. disposed shell) counts as finished

--- a/src/exec.ts
+++ b/src/exec.ts
@@ -226,7 +226,7 @@ function registerCommands(
           code: {
             type: 'string',
             description:
-              'The bash command to execute. Runs as a single pipeline: pipes (|), sequential separators (;), and file redirections (>, >>, 2>, <) are supported. Not supported (cockle limitations): chaining with && or ||, command substitution ($(...) and backticks), environment variable expansion ($VAR), and file-descriptor duplication (2>&1).'
+              'The bash command to execute. Runs as a single pipeline: pipes (|), sequential separators (;), and file redirections (>, >>, 2>, <) are supported. Not supported (cockle limitations): chaining with && or ||, command substitution ($(...) and backticks), environment variable expansion ($VAR), and file-descriptor duplication (2>&1). Run `cockle-config command` to list the commands available in the shell.'
           },
           terminalName: {
             type: 'string',

--- a/src/exec.ts
+++ b/src/exec.ts
@@ -11,31 +11,31 @@ import type { CommandRegistry } from '@lumino/commands';
 import { ILiteTerminalAPIClient } from './tokens';
 
 /**
- * Default timeout (in milliseconds) for execute-bash commands.
+ * Default timeout (in milliseconds) for execute-shell commands.
  */
 const DEFAULT_TIMEOUT_MS = 30000;
 
-type BashExecutionStatus = 'ok' | 'error' | 'timeout';
+type ShellExecutionStatus = 'ok' | 'error' | 'timeout';
 
-interface IExecuteBashResult {
+interface IExecuteShellResult {
   success: boolean;
-  status: BashExecutionStatus;
+  status: ShellExecutionStatus;
   output: string;
   exitCode: number | null;
-  terminalName: string;
+  shellName: string;
   duration: number;
   message: string;
 }
 
-interface ITerminalListItem {
+interface IShellListItem {
   name: string;
 }
 
 const COMMAND_IDS = {
-  executeBash: '@jupyterlite/terminal:execute-bash',
-  startTerminal: '@jupyterlite/terminal:start-terminal',
-  shutdownTerminal: '@jupyterlite/terminal:shutdown-terminal',
-  listTerminals: '@jupyterlite/terminal:list-terminals'
+  executeShell: '@jupyterlite/terminal:execute-shell',
+  startShell: '@jupyterlite/terminal:start-shell',
+  shutdownShell: '@jupyterlite/terminal:shutdown-shell',
+  listShells: '@jupyterlite/terminal:list-shells'
 } as const;
 
 interface IHeadlessSession {
@@ -127,7 +127,7 @@ async function runOnSession(
   session: IHeadlessSession,
   code: string,
   timeout: number
-): Promise<IExecuteBashResult> {
+): Promise<IExecuteShellResult> {
   const shellId = session.shell.shellId;
   // Fold any CR/CRLF inside the command to `\n` so it runs as a single command
   // rather than one line at a time when submitted with a trailing `\r`.
@@ -138,7 +138,7 @@ async function runOnSession(
       status: 'error',
       output: '',
       exitCode: null,
-      terminalName: shellId,
+      shellName: shellId,
       duration: 0,
       message: 'No command to run'
     };
@@ -190,7 +190,7 @@ async function runOnSession(
       status: 'timeout',
       output,
       exitCode: null,
-      terminalName: shellId,
+      shellName: shellId,
       duration,
       message: `Command timed out after ${timeout}ms`
     };
@@ -202,7 +202,7 @@ async function runOnSession(
     status: exitCode === 0 ? 'ok' : 'error',
     output,
     exitCode,
-    terminalName: shellId,
+    shellName: shellId,
     duration,
     message:
       exitCode === 0
@@ -215,10 +215,10 @@ function registerCommands(
   commands: CommandRegistry,
   pool: HeadlessShellPool
 ): void {
-  commands.addCommand(COMMAND_IDS.executeBash, {
-    label: 'Execute Bash',
+  commands.addCommand(COMMAND_IDS.executeShell, {
+    label: 'Execute Shell',
     caption:
-      'Execute a bash command in a headless cockle shell and capture the output',
+      'Execute a command in a headless cockle shell and capture the output',
     describedBy: {
       args: {
         type: 'object',
@@ -226,9 +226,9 @@ function registerCommands(
           code: {
             type: 'string',
             description:
-              'The bash command to execute. Runs as a single pipeline: pipes (|), sequential separators (;), and file redirections (>, >>, 2>, <) are supported. Not supported (cockle limitations): chaining with && or ||, command substitution ($(...) and backticks), environment variable expansion ($VAR), and file-descriptor duplication (2>&1). Run `cockle-config command` to list the commands available in the shell.'
+              'The shell command to execute. Runs as a single pipeline: pipes (|), sequential separators (;), and file redirections (>, >>, 2>, <) are supported. Not supported (cockle limitations): chaining with && or ||, command substitution ($(...) and backticks), environment variable expansion ($VAR), and file-descriptor duplication (2>&1). Run `cockle-config command` to list the commands available in the shell.'
           },
-          terminalName: {
+          shellName: {
             type: 'string',
             description:
               'Name of an existing headless shell to reuse. If not provided, a new shell is created and shut down after execution.'
@@ -236,7 +236,7 @@ function registerCommands(
           cwd: {
             type: 'string',
             description:
-              'Working directory for a newly created headless shell. Ignored when reusing an existing session via terminalName.'
+              'Working directory for a newly created headless shell. Ignored when reusing an existing session via shellName.'
           },
           timeout: {
             type: 'number',
@@ -246,17 +246,17 @@ function registerCommands(
         required: ['code']
       }
     },
-    execute: async (args: any): Promise<IExecuteBashResult> => {
+    execute: async (args: any): Promise<IExecuteShellResult> => {
       const code = args?.code;
-      const terminalName = args?.terminalName;
+      const shellName = args?.shellName;
       const cwd = args?.cwd;
       const timeout = args?.timeout ?? DEFAULT_TIMEOUT_MS;
 
       if (typeof code !== 'string' || code.length === 0) {
         throw new Error('code is required and must be a non-empty string');
       }
-      if (terminalName !== undefined && typeof terminalName !== 'string') {
-        throw new Error('terminalName must be a string');
+      if (shellName !== undefined && typeof shellName !== 'string') {
+        throw new Error('shellName must be a string');
       }
       if (cwd !== undefined && typeof cwd !== 'string') {
         throw new Error('cwd must be a string');
@@ -272,12 +272,10 @@ function registerCommands(
       let session: IHeadlessSession;
       let disposeAfter = false;
 
-      if (terminalName) {
-        const existing = pool.get(terminalName);
+      if (shellName) {
+        const existing = pool.get(shellName);
         if (!existing) {
-          throw new Error(
-            `No headless shell found with name '${terminalName}'`
-          );
+          throw new Error(`No headless shell found with name '${shellName}'`);
         }
         session = existing;
       } else {
@@ -299,10 +297,10 @@ function registerCommands(
     }
   });
 
-  commands.addCommand(COMMAND_IDS.startTerminal, {
-    label: 'Start Headless Terminal',
+  commands.addCommand(COMMAND_IDS.startShell, {
+    label: 'Start Headless Shell',
     caption:
-      'Start a new headless cockle shell that can be reused via execute-bash',
+      'Start a new headless cockle shell that can be reused via execute-shell',
     describedBy: {
       args: {
         type: 'object',
@@ -324,54 +322,52 @@ function registerCommands(
       return {
         success: true,
         message: `Headless shell '${session.shell.shellId}' started successfully`,
-        terminalName: session.shell.shellId
+        shellName: session.shell.shellId
       };
     }
   });
 
-  commands.addCommand(COMMAND_IDS.shutdownTerminal, {
-    label: 'Shutdown Headless Terminal',
+  commands.addCommand(COMMAND_IDS.shutdownShell, {
+    label: 'Shutdown Headless Shell',
     caption: 'Shut down a running headless cockle shell by name',
     describedBy: {
       args: {
         type: 'object',
         properties: {
-          terminalName: {
+          shellName: {
             type: 'string',
             description: 'The name of the headless shell to shut down.'
           }
         },
-        required: ['terminalName']
+        required: ['shellName']
       }
     },
     execute: async (args: any) => {
-      const terminalName = args?.terminalName;
-      if (typeof terminalName !== 'string' || terminalName.length === 0) {
-        throw new Error(
-          'terminalName is required and must be a non-empty string'
-        );
+      const shellName = args?.shellName;
+      if (typeof shellName !== 'string' || shellName.length === 0) {
+        throw new Error('shellName is required and must be a non-empty string');
       }
-      await pool.shutdown(terminalName);
+      await pool.shutdown(shellName);
       return {
         success: true,
-        message: `Headless shell '${terminalName}' shut down successfully`,
-        terminalName
+        message: `Headless shell '${shellName}' shut down successfully`,
+        shellName
       };
     }
   });
 
-  commands.addCommand(COMMAND_IDS.listTerminals, {
-    label: 'List Headless Terminals',
+  commands.addCommand(COMMAND_IDS.listShells, {
+    label: 'List Headless Shells',
     caption:
       'List running headless cockle shells (does not include user-opened terminals)',
     describedBy: { args: { type: 'object', properties: {} } },
     execute: async () => {
       const names = pool.names();
-      const terminals: ITerminalListItem[] = names.map(name => ({ name }));
+      const shells: IShellListItem[] = names.map(name => ({ name }));
       return {
         success: true,
-        terminals,
-        count: terminals.length,
+        shells,
+        count: shells.length,
         available: true
       };
     }
@@ -380,7 +376,7 @@ function registerCommands(
 
 /**
  * Plugin that registers headless shell exec commands backed by cockle.
- * These run bash code in a headless shell and capture its output and exit
+ * These run commands in a headless shell and capture their output and exit
  * code, without opening a terminal widget in the UI.
  */
 export const terminalExecPlugin: JupyterFrontEndPlugin<void> = {

--- a/src/exec.ts
+++ b/src/exec.ts
@@ -1,0 +1,398 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import type {
+  JupyterFrontEnd,
+  JupyterFrontEndPlugin
+} from '@jupyterlab/application';
+import type { IShell } from '@jupyterlite/cockle';
+import type { CommandRegistry } from '@lumino/commands';
+
+import { ILiteTerminalAPIClient } from './tokens';
+
+/**
+ * Default timeout (in milliseconds) for execute-bash commands.
+ */
+const DEFAULT_TIMEOUT_MS = 30000;
+
+type BashExecutionStatus = 'ok' | 'error' | 'timeout';
+
+interface IExecuteBashResult {
+  success: boolean;
+  status: BashExecutionStatus;
+  output: string;
+  exitCode: number | null;
+  terminalName: string;
+  duration: number;
+  message: string;
+}
+
+interface ITerminalListItem {
+  name: string;
+}
+
+const COMMAND_IDS = {
+  executeBash: '@jupyterlite/terminal:execute-bash',
+  startTerminal: '@jupyterlite/terminal:start-terminal',
+  shutdownTerminal: '@jupyterlite/terminal:shutdown-terminal',
+  listTerminals: '@jupyterlite/terminal:list-terminals'
+} as const;
+
+interface IHeadlessSession {
+  shell: IShell;
+  output: string;
+  busy: boolean;
+  timedOut: boolean;
+}
+
+/**
+ * A pool of headless cockle shells used by the exec commands. These shells
+ * are independent of the JupyterLab terminal service, so they do not appear
+ * in the terminal widget list or in `LiteTerminalAPIClient.listRunning()`.
+ */
+class HeadlessShellPool {
+  constructor(client: ILiteTerminalAPIClient) {
+    this._client = client;
+  }
+
+  async create(options: { cwd?: string }): Promise<IHeadlessSession> {
+    const name = this._nextAvailableName();
+    let output = '';
+    // Empty PS1 so the shell prints no prompt, keeping the captured output clean.
+    const shell = await this._client.createHeadlessShell({
+      shellId: name,
+      cwd: options.cwd,
+      environment: { PS1: '' },
+      outputCallback: text => {
+        output += text;
+      }
+    });
+    const session: IHeadlessSession = {
+      shell,
+      get output() {
+        return output;
+      },
+      busy: false,
+      timedOut: false
+    };
+    this._sessions.set(name, session);
+    shell.disposed.connect(() => {
+      // Keep the pool in sync if the shell disposes itself (e.g. on init failure).
+      this._sessions.delete(name);
+    });
+    return session;
+  }
+
+  get(name: string): IHeadlessSession | undefined {
+    return this._sessions.get(name);
+  }
+
+  names(): string[] {
+    return Array.from(this._sessions.keys());
+  }
+
+  async shutdown(name: string): Promise<void> {
+    const session = this._sessions.get(name);
+    if (!session) {
+      throw new Error(`No headless shell found with name '${name}'`);
+    }
+    this._sessions.delete(name);
+    session.shell.dispose();
+  }
+
+  private _nextAvailableName(): string {
+    return `headless-${this._nextId++}`;
+  }
+
+  private _client: ILiteTerminalAPIClient;
+  private _sessions = new Map<string, IHeadlessSession>();
+  private _nextId = 1;
+}
+
+/**
+ * Normalize the captured TTY buffer for callers that expect pipe-like output.
+ * Cockle translates `\n` to `\r\n` on TTY writes (ONLCR) and echoes the input
+ * line back, so undo both: convert `\r\n` to `\n` and strip the leading echo.
+ */
+function cleanCapturedOutput(captured: string, code: string): string {
+  const normalized = captured.replace(/\r\n/g, '\n');
+  const expected = code + '\n';
+  if (normalized.startsWith(expected)) {
+    return normalized.slice(expected.length);
+  }
+  return normalized;
+}
+
+async function runOnSession(
+  session: IHeadlessSession,
+  code: string,
+  timeout: number
+): Promise<IExecuteBashResult> {
+  const shellId = session.shell.shellId;
+  // Cockle runs the command on `\r`, so fold any CR/CRLF inside the command
+  // into `\n` to avoid executing a multi-line command one line too early.
+  const command = code.trim().replace(/\r\n?/g, '\n');
+  if (command.length === 0) {
+    return {
+      success: false,
+      status: 'error',
+      output: '',
+      exitCode: null,
+      terminalName: shellId,
+      duration: 0,
+      message: 'No command to run'
+    };
+  }
+
+  // A timed-out command keeps running in the worker, leaving the session in an
+  // unknown state, so refuse to reuse it. Also refuse overlapping commands,
+  // whose input and captured output would otherwise interleave.
+  if (session.timedOut) {
+    throw new Error(
+      `Headless shell '${shellId}' is no longer usable after a command timed out`
+    );
+  }
+  if (session.busy) {
+    throw new Error(`Headless shell '${shellId}' is already running a command`);
+  }
+  session.busy = true;
+
+  const startTime = Date.now();
+  const startLen = session.output.length;
+  // `input()` resolves once the worker has run the command, so it doubles as
+  // the "command finished" signal. Cockle has no interrupt, so race it against
+  // a timer to avoid hanging on a command that blocks (e.g. on stdin).
+  const inputDone = session.shell.input(command + '\r').then(
+    () => false,
+    () => false // a late rejection (e.g. disposed shell) counts as finished
+  );
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timedOut = await Promise.race([
+    inputDone,
+    new Promise<boolean>(resolve => {
+      timer = setTimeout(() => resolve(true), timeout);
+    })
+  ]);
+  if (timer !== undefined) {
+    clearTimeout(timer);
+  }
+  session.busy = false;
+  if (timedOut) {
+    session.timedOut = true;
+  }
+
+  const output = cleanCapturedOutput(session.output.slice(startLen), command);
+  const duration = Date.now() - startTime;
+
+  if (timedOut) {
+    return {
+      success: false,
+      status: 'timeout',
+      output,
+      exitCode: null,
+      terminalName: shellId,
+      duration,
+      message: `Command timed out after ${timeout}ms`
+    };
+  }
+
+  const exitCode = await session.shell.exitCode();
+  return {
+    success: exitCode === 0,
+    status: exitCode === 0 ? 'ok' : 'error',
+    output,
+    exitCode,
+    terminalName: shellId,
+    duration,
+    message:
+      exitCode === 0
+        ? 'Command executed successfully'
+        : `Command failed with exit code ${exitCode}`
+  };
+}
+
+function registerCommands(
+  commands: CommandRegistry,
+  pool: HeadlessShellPool
+): void {
+  commands.addCommand(COMMAND_IDS.executeBash, {
+    label: 'Execute Bash',
+    caption:
+      'Execute a bash command in a headless cockle shell and capture the output',
+    describedBy: {
+      args: {
+        type: 'object',
+        properties: {
+          code: {
+            type: 'string',
+            description:
+              'The bash command to execute. Runs as a single pipeline: pipes (|), sequential separators (;), and file redirections (>, >>, 2>, <) are supported. Not supported (cockle limitations): chaining with && or ||, command substitution ($(...) and backticks), environment variable expansion ($VAR), and file-descriptor duplication (2>&1).'
+          },
+          terminalName: {
+            type: 'string',
+            description:
+              'Name of an existing headless shell to reuse. If not provided, a new shell is created and shut down after execution.'
+          },
+          cwd: {
+            type: 'string',
+            description:
+              'Working directory for a newly created headless shell. Ignored when reusing an existing session via terminalName.'
+          },
+          timeout: {
+            type: 'number',
+            description: `Maximum time in milliseconds to wait for the command before returning a timeout result (default: ${DEFAULT_TIMEOUT_MS}). Cockle cannot interrupt a running command, so it keeps running after a timeout.`
+          }
+        },
+        required: ['code']
+      }
+    },
+    execute: async (args: any): Promise<IExecuteBashResult> => {
+      const code = args?.code;
+      const terminalName = args?.terminalName;
+      const cwd = args?.cwd;
+      const timeout = args?.timeout ?? DEFAULT_TIMEOUT_MS;
+
+      if (typeof code !== 'string' || code.length === 0) {
+        throw new Error('code is required and must be a non-empty string');
+      }
+      if (terminalName !== undefined && typeof terminalName !== 'string') {
+        throw new Error('terminalName must be a string');
+      }
+      if (cwd !== undefined && typeof cwd !== 'string') {
+        throw new Error('cwd must be a string');
+      }
+      if (
+        typeof timeout !== 'number' ||
+        !Number.isFinite(timeout) ||
+        timeout <= 0
+      ) {
+        throw new Error('timeout must be a positive number');
+      }
+
+      let session: IHeadlessSession;
+      let disposeAfter = false;
+
+      if (terminalName) {
+        const existing = pool.get(terminalName);
+        if (!existing) {
+          throw new Error(
+            `No headless shell found with name '${terminalName}'`
+          );
+        }
+        session = existing;
+      } else {
+        session = await pool.create({ cwd });
+        disposeAfter = true;
+      }
+
+      try {
+        return await runOnSession(session, code, timeout);
+      } finally {
+        if (disposeAfter) {
+          try {
+            await pool.shutdown(session.shell.shellId);
+          } catch {
+            // Best-effort: do not mask the real result with a teardown error.
+          }
+        }
+      }
+    }
+  });
+
+  commands.addCommand(COMMAND_IDS.startTerminal, {
+    label: 'Start Headless Terminal',
+    caption:
+      'Start a new headless cockle shell that can be reused via execute-bash',
+    describedBy: {
+      args: {
+        type: 'object',
+        properties: {
+          cwd: {
+            type: 'string',
+            description:
+              'Working directory for the new headless shell (optional).'
+          }
+        }
+      }
+    },
+    execute: async (args: any) => {
+      const cwd = args?.cwd;
+      if (cwd !== undefined && typeof cwd !== 'string') {
+        throw new Error('cwd must be a string');
+      }
+      const session = await pool.create({ cwd });
+      return {
+        success: true,
+        message: `Headless shell '${session.shell.shellId}' started successfully`,
+        terminalName: session.shell.shellId
+      };
+    }
+  });
+
+  commands.addCommand(COMMAND_IDS.shutdownTerminal, {
+    label: 'Shutdown Headless Terminal',
+    caption: 'Shut down a running headless cockle shell by name',
+    describedBy: {
+      args: {
+        type: 'object',
+        properties: {
+          terminalName: {
+            type: 'string',
+            description: 'The name of the headless shell to shut down.'
+          }
+        },
+        required: ['terminalName']
+      }
+    },
+    execute: async (args: any) => {
+      const terminalName = args?.terminalName;
+      if (typeof terminalName !== 'string' || terminalName.length === 0) {
+        throw new Error(
+          'terminalName is required and must be a non-empty string'
+        );
+      }
+      await pool.shutdown(terminalName);
+      return {
+        success: true,
+        message: `Headless shell '${terminalName}' shut down successfully`,
+        terminalName
+      };
+    }
+  });
+
+  commands.addCommand(COMMAND_IDS.listTerminals, {
+    label: 'List Headless Terminals',
+    caption:
+      'List running headless cockle shells (does not include user-opened terminals)',
+    describedBy: { args: { type: 'object', properties: {} } },
+    execute: async () => {
+      const names = pool.names();
+      const terminals: ITerminalListItem[] = names.map(name => ({ name }));
+      return {
+        success: true,
+        terminals,
+        count: terminals.length,
+        available: true
+      };
+    }
+  });
+}
+
+/**
+ * Plugin that registers headless shell exec commands backed by cockle.
+ * These run bash code in a headless shell and capture its output and exit
+ * code, without opening a terminal widget in the UI.
+ */
+export const terminalExecPlugin: JupyterFrontEndPlugin<void> = {
+  id: '@jupyterlite/terminal:exec',
+  description: 'AI-friendly headless shell exec commands backed by cockle',
+  autoStart: true,
+  requires: [ILiteTerminalAPIClient],
+  activate: (
+    app: JupyterFrontEnd,
+    liteTerminalAPIClient: ILiteTerminalAPIClient
+  ): void => {
+    const pool = new HeadlessShellPool(liteTerminalAPIClient);
+    registerCommands(app.commands, pool);
+  }
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { WebSocket } from 'mock-socket';
 
 import { LiteTerminalAPIClient } from './client';
+import { terminalExecPlugin } from './exec';
 import { ILiteTerminalAPIClient } from './tokens';
 
 /**
@@ -140,7 +141,8 @@ export default [
   terminalClientPlugin,
   terminalManagerPlugin,
   terminalServiceWorkerPlugin,
-  terminalThemeChangePlugin
+  terminalThemeChangePlugin,
+  terminalExecPlugin
 ];
 
 // Export ILiteTerminalAPIClient so that other extensions can register external commands.

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -1,6 +1,8 @@
 import type { Terminal } from '@jupyterlab/services';
 import type {
   IExternalCommand,
+  IOutputCallback,
+  IShell,
   IStdinReply,
   IStdinRequest
 } from '@jupyterlite/cockle';
@@ -39,6 +41,19 @@ export interface ILiteTerminalAPIClient extends Terminal.ITerminalAPIClient {
    * Register an external command that will be available in all terminals.
    */
   registerExternalCommand(options: IExternalCommand.IOptions): void;
+
+  /**
+   * Create a headless cockle shell that shares the client's stdin routing,
+   * aliases, environment variables, and external commands. The returned shell
+   * is already started and ready to receive input via `input()`.
+   */
+  createHeadlessShell(options: {
+    shellId: string;
+    cwd?: string;
+    environment?: { [key: string]: string | undefined };
+    outputCallback: IOutputCallback;
+    readyTimeoutMs?: number;
+  }): Promise<IShell>;
 
   /**
    * Signal emitted when a terminal is disposed.

--- a/ui-tests/tests/exec.spec.ts
+++ b/ui-tests/tests/exec.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test } from '@jupyterlab/galata';
+import type { IJupyterLabPageFixture } from '@jupyterlab/galata';
+
+const EXECUTE_BASH = '@jupyterlite/terminal:execute-bash';
+const START_TERMINAL = '@jupyterlite/terminal:start-terminal';
+const SHUTDOWN_TERMINAL = '@jupyterlite/terminal:shutdown-terminal';
+const LIST_TERMINALS = '@jupyterlite/terminal:list-terminals';
+
+async function execute(
+  page: IJupyterLabPageFixture,
+  id: string,
+  args: Record<string, any> = {}
+) {
+  return await page.evaluate(
+    ({ id, args }) => window.galata.app.commands.execute(id, args),
+    { id, args }
+  );
+}
+
+test.describe('programmatic commands', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto();
+  });
+
+  test('execute-bash captures output and exit code', async ({ page }) => {
+    const result = await execute(page, EXECUTE_BASH, { code: 'echo hello' });
+    expect(result.success).toBe(true);
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain('hello');
+
+    // The throwaway shell is disposed once the command finishes.
+    const list = await execute(page, LIST_TERMINALS);
+    expect(list.count).toBe(0);
+  });
+
+  test('execute-bash reports a non-zero exit code', async ({ page }) => {
+    const result = await execute(page, EXECUTE_BASH, { code: 'false' });
+    expect(result.success).toBe(false);
+    expect(result.status).toBe('error');
+    expect(result.exitCode).not.toBe(0);
+  });
+
+  test('start, reuse, list and shutdown a headless shell', async ({ page }) => {
+    const started = await execute(page, START_TERMINAL);
+    expect(started.success).toBe(true);
+    const name = started.terminalName;
+
+    let list = await execute(page, LIST_TERMINALS);
+    expect(list.count).toBe(1);
+    expect(list.terminals[0].name).toBe(name);
+
+    // State persists across calls on the same shell.
+    await execute(page, EXECUTE_BASH, { code: 'cd /', terminalName: name });
+    const pwd = await execute(page, EXECUTE_BASH, {
+      code: 'pwd',
+      terminalName: name
+    });
+    expect(pwd.output.trim()).toBe('/');
+
+    await execute(page, SHUTDOWN_TERMINAL, { terminalName: name });
+    list = await execute(page, LIST_TERMINALS);
+    expect(list.count).toBe(0);
+  });
+});

--- a/ui-tests/tests/exec.spec.ts
+++ b/ui-tests/tests/exec.spec.ts
@@ -1,10 +1,10 @@
 import { expect, test } from '@jupyterlab/galata';
 import type { IJupyterLabPageFixture } from '@jupyterlab/galata';
 
-const EXECUTE_BASH = '@jupyterlite/terminal:execute-bash';
-const START_TERMINAL = '@jupyterlite/terminal:start-terminal';
-const SHUTDOWN_TERMINAL = '@jupyterlite/terminal:shutdown-terminal';
-const LIST_TERMINALS = '@jupyterlite/terminal:list-terminals';
+const EXECUTE_SHELL = '@jupyterlite/terminal:execute-shell';
+const START_SHELL = '@jupyterlite/terminal:start-shell';
+const SHUTDOWN_SHELL = '@jupyterlite/terminal:shutdown-shell';
+const LIST_SHELLS = '@jupyterlite/terminal:list-shells';
 
 async function execute(
   page: IJupyterLabPageFixture,
@@ -22,43 +22,43 @@ test.describe('programmatic commands', () => {
     await page.goto();
   });
 
-  test('execute-bash captures output and exit code', async ({ page }) => {
-    const result = await execute(page, EXECUTE_BASH, { code: 'echo hello' });
+  test('execute-shell captures output and exit code', async ({ page }) => {
+    const result = await execute(page, EXECUTE_SHELL, { code: 'echo hello' });
     expect(result.success).toBe(true);
     expect(result.exitCode).toBe(0);
     expect(result.output).toContain('hello');
 
     // The throwaway shell is disposed once the command finishes.
-    const list = await execute(page, LIST_TERMINALS);
+    const list = await execute(page, LIST_SHELLS);
     expect(list.count).toBe(0);
   });
 
-  test('execute-bash reports a non-zero exit code', async ({ page }) => {
-    const result = await execute(page, EXECUTE_BASH, { code: 'false' });
+  test('execute-shell reports a non-zero exit code', async ({ page }) => {
+    const result = await execute(page, EXECUTE_SHELL, { code: 'false' });
     expect(result.success).toBe(false);
     expect(result.status).toBe('error');
     expect(result.exitCode).not.toBe(0);
   });
 
   test('start, reuse, list and shutdown a headless shell', async ({ page }) => {
-    const started = await execute(page, START_TERMINAL);
+    const started = await execute(page, START_SHELL);
     expect(started.success).toBe(true);
-    const name = started.terminalName;
+    const name = started.shellName;
 
-    let list = await execute(page, LIST_TERMINALS);
+    let list = await execute(page, LIST_SHELLS);
     expect(list.count).toBe(1);
-    expect(list.terminals[0].name).toBe(name);
+    expect(list.shells[0].name).toBe(name);
 
     // State persists across calls on the same shell.
-    await execute(page, EXECUTE_BASH, { code: 'cd /', terminalName: name });
-    const pwd = await execute(page, EXECUTE_BASH, {
+    await execute(page, EXECUTE_SHELL, { code: 'cd /', shellName: name });
+    const pwd = await execute(page, EXECUTE_SHELL, {
       code: 'pwd',
-      terminalName: name
+      shellName: name
     });
     expect(pwd.output.trim()).toBe('/');
 
-    await execute(page, SHUTDOWN_TERMINAL, { terminalName: name });
-    list = await execute(page, LIST_TERMINALS);
+    await execute(page, SHUTDOWN_SHELL, { shellName: name });
+    list = await execute(page, LIST_SHELLS);
     expect(list.count).toBe(0);
   });
 });


### PR DESCRIPTION
Expose a couple of JupyterLab commands to allow programmatic execution of command in the terminal:

| Command                                   | Description                                            |
| ----------------------------------------- | ------------------------------------------------------ |
| `@jupyterlite/terminal:execute-shell`      | Run a bash command and return its output and exit code |
| `@jupyterlite/terminal:start-shell`    | Start a reusable headless shell                        |
| `@jupyterlite/terminal:shutdown-shell` | Shut down a headless shell by name                     |
| `@jupyterlite/terminal:list-shells`    | List the running headless shells                       |


- [x] Add new commands
- [x] Add new UI tests

https://github.com/user-attachments/assets/b768dfc5-cee3-480a-a6f4-abc0eb9f1f55

