### PR TITLE
Support ability to subclass `TerminalAPIClient` to `createShell`

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
         "@jupyterlab/services": "^7.5.0",
         "@jupyterlab/settingregistry": "^4.5.0",
         "@jupyterlite/apputils": "^0.7.0",
-        "@jupyterlite/cockle": "^1.5.2-a0",
+        "@jupyterlite/cockle": "^1.5.2-a1",
         "@jupyterlite/services": "^0.7.0",
         "@lumino/coreutils": "^2.2.1",
         "@lumino/signaling": "^2.1.4",

--- a/src/client.ts
+++ b/src/client.ts
@@ -17,7 +17,8 @@ import { Signal } from '@lumino/signaling';
 import type { Client as WebSocketClient } from 'mock-socket';
 import { Server as WebSocketServer } from 'mock-socket';
 
-import { Shell } from './shell';
+import type { ITerminalShell } from './shell';
+import { TerminalShell } from './shell';
 import type { ILiteTerminalAPIClient } from './tokens';
 
 /**
@@ -31,7 +32,6 @@ export class LiteTerminalAPIClient implements ILiteTerminalAPIClient {
   constructor(options: { serverSettings?: ServerConnection.ISettings } = {}) {
     this.serverSettings =
       options.serverSettings ?? ServerConnection.makeSettings();
-    this._shellManager = new ShellManager();
   }
 
   /**
@@ -46,7 +46,7 @@ export class LiteTerminalAPIClient implements ILiteTerminalAPIClient {
    * Function that handles stdin requests received from service worker.
    */
   async handleStdin(request: IStdinRequest): Promise<IStdinReply> {
-    return await this._shellManager.handleStdin(request);
+    return await Private.shellManager.handleStdin(request);
   }
 
   get isAvailable(): boolean {
@@ -62,7 +62,7 @@ export class LiteTerminalAPIClient implements ILiteTerminalAPIClient {
     // Create shell.
     const name = options?.name ?? this._nextAvailableName();
     const { baseUrl, wsUrl } = this.serverSettings;
-    const shell = new Shell({
+    const shell = await this.createShell({
       mountpoint: '/drive',
       cwd: options?.cwd,
       baseUrl,
@@ -75,17 +75,17 @@ export class LiteTerminalAPIClient implements ILiteTerminalAPIClient {
       environment: this._environment,
       externalCommands: this._externalCommands,
       shellId: name,
-      shellManager: this._shellManager,
+      shellManager: Private.shellManager,
       outputCallback: text => {
         const msg = JSON.stringify(['stdout', text]);
         shell.socket?.send(msg);
       }
     });
-    this._shells.set(name, shell);
+    Private.shells.set(name, shell);
 
     // Hook to connect socket to shell.
     const hook = async (
-      shell: Shell,
+      shell: ITerminalShell,
       socket: WebSocketClient
     ): Promise<void> => {
       shell.socket = socket;
@@ -163,7 +163,7 @@ export class LiteTerminalAPIClient implements ILiteTerminalAPIClient {
         ? { ...this._environment, ...options.environment }
         : this._environment;
     // `color: true` keeps TERM/TERMINFO populated for commands that need them.
-    const shell = new Shell({
+    const shell = await this.createShell({
       shellId: options.shellId,
       mountpoint: '/drive',
       cwd: options.cwd,
@@ -173,7 +173,7 @@ export class LiteTerminalAPIClient implements ILiteTerminalAPIClient {
         'extensions/@jupyterlite/terminal/static/wasm/'
       ),
       browsingContextId: this._browsingContextId,
-      shellManager: this._shellManager,
+      shellManager: Private.shellManager,
       aliases: this._aliases,
       environment,
       externalCommands: this._externalCommands,
@@ -212,11 +212,11 @@ export class LiteTerminalAPIClient implements ILiteTerminalAPIClient {
   }
 
   async shutdown(name: string): Promise<void> {
-    const shell = this._shells.get(name);
+    const shell = Private.shells.get(name);
     if (shell !== undefined) {
       shell.socket?.send(JSON.stringify(['disconnect']));
       shell.socket?.close();
-      this._shells.delete(name);
+      Private.shells.delete(name);
       shell.dispose();
     }
   }
@@ -226,13 +226,19 @@ export class LiteTerminalAPIClient implements ILiteTerminalAPIClient {
   }
 
   themeChange(isDarkMode?: boolean): void {
-    for (const shell of this._shells.values()) {
+    for (const shell of Private.shells.values()) {
       shell.themeChange(isDarkMode);
     }
   }
 
+  protected async createShell(
+    options: ITerminalShell.IOptions
+  ): Promise<ITerminalShell> {
+    return new TerminalShell(options);
+  }
+
   private get _models(): Terminal.IModel[] {
-    return Array.from(this._shells.keys(), name => {
+    return Array.from(Private.shells.keys(), name => {
       return { name };
     });
   }
@@ -240,7 +246,7 @@ export class LiteTerminalAPIClient implements ILiteTerminalAPIClient {
   private _nextAvailableName(): string {
     for (let i = 1; ; ++i) {
       const name = `${i}`;
-      if (!this._shells.has(name)) {
+      if (!Private.shells.has(name)) {
         return name;
       }
     }
@@ -250,7 +256,13 @@ export class LiteTerminalAPIClient implements ILiteTerminalAPIClient {
   private _environment?: { [key: string]: string | undefined };
   private _browsingContextId?: string;
   private _externalCommands: IExternalCommand.IOptions[] = [];
-  private _shellManager: IShellManager;
-  private _shells = new Map<string, Shell>();
   private _terminalDisposed = new Signal<this, string>(this);
+}
+
+/**
+ * A namespace for private data.
+ */
+namespace Private {
+  export const shellManager: IShellManager = new ShellManager();
+  export const shells = new Map<string, ITerminalShell>();
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,8 @@ import { WebSocket } from 'mock-socket';
 import { LiteTerminalAPIClient } from './client';
 import { terminalExecPlugin } from './exec';
 import { ILiteTerminalAPIClient } from './tokens';
-import { Shell } from './shell';
+import { ITerminalShell } from './shell';
+import { TerminalShell } from './shell';
 
 /**
  * Plugin containing client for in-browser terminals.
@@ -146,5 +147,9 @@ export default [
   terminalExecPlugin
 ];
 
-// Export ILiteTerminalAPIClient so that other extensions can register external commands.
-export { ILiteTerminalAPIClient, Shell };
+export {
+  ILiteTerminalAPIClient,
+  ITerminalShell,
+  LiteTerminalAPIClient,
+  TerminalShell
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,9 +20,8 @@ import { WebSocket } from 'mock-socket';
 
 import { LiteTerminalAPIClient } from './client';
 import { terminalExecPlugin } from './exec';
+import { ITerminalShell, TerminalShell } from './shell';
 import { ILiteTerminalAPIClient } from './tokens';
-import { ITerminalShell } from './shell';
-import { TerminalShell } from './shell';
 
 /**
  * Plugin containing client for in-browser terminals.

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -3,23 +3,31 @@ import { BaseShell } from '@jupyterlite/cockle';
 
 import type { Client as WebSocketClient } from 'mock-socket';
 
+export interface ITerminalShell extends IShell {
+  socket?: WebSocketClient;
+}
+
+export namespace ITerminalShell {
+  export interface IOptions extends IShell.IOptions {}
+}
+
 /**
  * Shell class that uses web worker that plugs into a DriveFS via the service worker.
  */
-export class Shell extends BaseShell {
+export class TerminalShell extends BaseShell {
   /**
    * Instantiate a new Shell
    *
    * @param options The instantiation options for a new shell
    */
-  constructor(options: IShell.IOptions) {
+  constructor(options: ITerminalShell.IOptions) {
     super(options);
   }
 
   /**
    * Load the web worker.
    */
-  protected override initWorker(options: IShell.IOptions): Worker {
+  protected override initWorker(options: ITerminalShell.IOptions): Worker {
     console.log('Terminal create webworker');
     return new Worker(new URL('./worker.js', import.meta.url), {
       type: 'module'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2851,9 +2851,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlite/cockle@npm:^1.5.2-a0":
-  version: 1.5.2-a0
-  resolution: "@jupyterlite/cockle@npm:1.5.2-a0"
+"@jupyterlite/cockle@npm:^1.5.2-a1":
+  version: 1.5.2-a1
+  resolution: "@jupyterlite/cockle@npm:1.5.2-a1"
   dependencies:
     "@lumino/coreutils": ^2.2.0
     "@lumino/disposable": ^2.1.3
@@ -2862,7 +2862,7 @@ __metadata:
     deepmerge-ts: ^7.1.4
     rimraf: ^6.0.1
     zod: ^3.23.8
-  checksum: 95464243da9ec0b4a4fe97184b7e1c154c3a578e7a9f3fd1d8f7a8d2d450096d943b858095a9e3ae7ebf88af14f447d99bae608b68ab0e16202faef277fd4780
+  checksum: 0ab1395bd8cec6ecaa04fc28bd8fb50b50a8db1b17cd9103bb6b9cb0555700f52ee47632d304205381eb4539033c6872b69e1ff6c62316e460c23d11e466b959
   languageName: node
   linkType: hard
 
@@ -2915,7 +2915,7 @@ __metadata:
     "@jupyterlab/settingregistry": ^4.5.0
     "@jupyterlab/testutils": ^4.5.0
     "@jupyterlite/apputils": ^0.7.0
-    "@jupyterlite/cockle": ^1.5.2-a0
+    "@jupyterlite/cockle": ^1.5.2-a1
     "@jupyterlite/services": ^0.7.0
     "@lumino/coreutils": ^2.2.1
     "@lumino/signaling": ^2.1.4


### PR DESCRIPTION
This is an enhancement to enable downstream extensions to more easily replace and subclass the functionality here. The key change is that `LiteTerminalAPIClient` can now be subclassed and the `protected createShell` function overridden to instantiate a different `TerminalShell`-derived class and/or change the `options` passed to the constructor.

Other changes:
- Better exported types for `ITerminalShell`, `TerminalShell` to differentiate between `cockle` `IShell` and `Shell`.
- Storage of `shells` and the `shellManager` is in a private namespace.

Uses the latest `1.5.2-a1` pre-release of `cockle`.