### PR TITLE
Use correct extension directory name

### DIFF
--- a/jupyterlite_terminal/__init__.py
+++ b/jupyterlite_terminal/__init__.py
@@ -9,8 +9,11 @@ except ImportError:
     __version__ = "dev"
 
 
+__all__ = ["__version__", "_jupyter_labextension_paths"]
+
+
 def _jupyter_labextension_paths():
     return [{
         "src": "labextension",
-        "dest": "jupyterlite-terminal"
+        "dest": "@jupyterlite/terminal"
     }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,8 +42,8 @@ artifacts = ["jupyterlite_terminal/labextension"]
 exclude = [".github", "binder"]
 
 [tool.hatch.build.targets.wheel.shared-data]
-"jupyterlite_terminal/labextension" = "share/jupyter/labextensions/jupyterlite-terminal"
-"install.json" = "share/jupyter/labextensions/jupyterlite-terminal/install.json"
+"jupyterlite_terminal/labextension" = "share/jupyter/labextensions/@jupyterlite/terminal"
+"install.json" = "share/jupyter/labextensions/@jupyterlite/terminal/install.json"
 
 [tool.hatch.build.hooks.version]
 path = "jupyterlite_terminal/_version.py"


### PR DESCRIPTION
Fix the extension directory name which is `@jupyterlite/terminal` rather than `jupyterlite-terminal`. This has not been a problem for JupyterLite deployments, but it is a problem for hybrid JupyterLab/JupyterLite deployments such as in [jupyterlab-hybrid-kernels](https://github.com/jupyterlab-contrib/jupyterlab-hybrid-kernels) which I am working on.